### PR TITLE
docs: add bilingual SDK technical evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,83 +1,189 @@
-Ai-Thinker Ai-WB2 Wireless Modules Development Framework
-=========
+<div align="center">
 
-Base on th Bouffalolab bl_iot_sdk. Support BL602 Wi-Fi/BLE Combo RISC-V based Chip and BL70X Zigbee/BLE RISC-V based Chip.
+# Ai-Thinker Ai-WB2 Development Framework
 
-# Linux Users
+</div>
 
-## Step 1. Install Prerequisites
+[![中文](https://img.shields.io/badge/中文-README-blue)](README.zh.md)
 
-In order to use Ai-WB2 Development Framework with the Ai-WB2, you need to install some software packages based on your Operating System. This setup guide will help you on getting everything installed on Linux and macOS based systems.
+## Project overview
 
-- One liner for Debian or Ubuntu :
+Ai-Thinker Ai-WB2 Development Framework is an embedded SDK for Ai-WB2 wireless modules based on Bouffalo Lab's BL IoT SDK. It targets the BL602 Wi-Fi/BLE RISC-V platform and also contains BL70x platform components and examples. The repository provides chip support, FreeRTOS, peripheral and network components, a Make-based build system, fixed cross-toolchains, flashing tools, and application examples.
 
-`sudo apt install build-essential python3 python3-pip git screen`
+> This repository contains firmware source code rather than a desktop application. Compilation can be performed on Linux or WSL2. Flashing and functional acceptance require a compatible Ai-WB2 board and correct wiring.
 
-- One liner for Arch:
+## Supported scope
 
-`sudo pacman -S base-devel python python-pip git screen`
+- Primary module: Ai-Thinker Ai-WB2;
+- Primary chip: BL602, with BL70x-related platform content also present;
+- CPU architecture: RISC-V;
+- Operating system: FreeRTOS;
+- Interfaces and middleware: GPIO, UART, I²C, SPI, PWM, ADC, Wi-Fi, BLE, TCP/IP, file systems, cryptography, and other components selected by each application;
+- Build system: GNU Make with repository-pinned RISC-V toolchains for Linux, macOS, and MSYS.
 
-- Next, clone the SDK repository:
+The repository contains 241 application Makefiles under `applications/`, grouped into getting-started, peripheral, Wi-Fi, Bluetooth, protocol, security, storage, system, and IoT-solution examples. They are independent projects; building `helloworld` validates the common BL602 build path, not every example or hardware feature.
 
-`git clone --recursive https://github.com/Ai-Thinker-Open/Ai-Thinker-WB2.git` 
+See [Code Entry](docs/CODE_ENTRY.md), [Architecture](docs/ARCHITECTURE.md), and [Build Validation](docs/BUILD_VALIDATION.md) for source-backed technical evidence.
 
-if you are coding in the China , recommend you to clone the repository :
+## Quick start
 
-`git clone --recursive https://gitee.com/Ai-Thinker-Open/Ai-Thinker-WB2` 
+On Ubuntu or WSL2:
 
-## Step 2. Modify Permission
-Modify the permissions of the compilation tool chain to enable executable functions.
-- Darwin
-```shell
- cd toolchain/riscv/Darwin/
- . chmod755.sh 
-```
-- Linux
-```shell
- cd toolchain/riscv/Linux/
- . chmod755.sh 
-```
-- MSYS
-```shell
- cd toolchain/riscv/MSYS/
- . chmod755.sh 
-```
-## Step 3. Compiling
+```bash
+sudo apt update
+sudo apt install build-essential git python3 python3-pip
 
-For example, run the cd applications/get-started/helloworld project to compile :
+git clone --recurse-submodules https://github.com/Ai-Thinker-Open/Ai-Thinker-WB2.git
+cd Ai-Thinker-WB2
 
-```
+find toolchain/riscv/Linux/bin toolchain/riscv/Linux/libexec \
+  -type f -exec chmod u+x {} +
+
 cd applications/get-started/helloworld
 make -j8
 ```
 
-## Step 4. download
+The main outputs are written to `applications/get-started/helloworld/build_out/`.
 
-Please connect your Ai-WB2 Serial Development board , and press the EN button according to the prompts.
+## Prerequisites
 
+Install these packages on Debian or Ubuntu:
+
+```bash
+sudo apt install build-essential git python3 python3-pip
 ```
+
+On Arch Linux:
+
+```bash
+sudo pacman -S base-devel git python python-pip
+```
+
+Use a case-sensitive Linux file system for the fastest and most predictable builds. WSL2 users can build directly from a Windows drive, but a WSL2-native directory avoids Windows timestamp and file-mode differences.
+
+## Get the source
+
+Clone all fixed toolchain and flashing-tool submodules:
+
+```bash
+git clone --recurse-submodules https://github.com/Ai-Thinker-Open/Ai-Thinker-WB2.git
+cd Ai-Thinker-WB2
+git submodule status --recursive
+```
+
+If the repository was cloned without submodules:
+
+```bash
+git submodule update --init --recursive
+```
+
+Do not switch a submodule to an arbitrary branch when a reproducible build is required. The superproject records the expected commit for each toolchain and flashing-tool dependency.
+
+## Prepare the toolchain
+
+Git checkouts on Windows-mounted disks may not preserve Unix execute permissions. On Linux or WSL2, run:
+
+```bash
+find toolchain/riscv/Linux/bin toolchain/riscv/Linux/libexec \
+  -type f -exec chmod u+x {} +
+```
+
+This command changes only local execute permissions. It does not edit source files or move the pinned toolchain commit.
+
+## Build an application
+
+Each application directory contains its own `Makefile`, `proj_config.mk`, application component, and optional local components. Build the official `helloworld` example with:
+
+```bash
+cd applications/get-started/helloworld
+make clean
+make -j8
+```
+
+Useful targets include:
+
+```bash
+make help
+make list-components
+make clean
+```
+
+The `helloworld` outputs are:
+
+- `build_out/helloworld.elf`: linked firmware with symbols;
+- `build_out/helloworld.bin`: application binary;
+- `build_out/helloworld.flash.bin`: flashing binary;
+- `build_out/helloworld.map`: linker map.
+
+## Use an example as a starting point
+
+The application entry for `helloworld` is `applications/get-started/helloworld/helloworld/main.c`:
+
+```c
+void main(void)
+{
+    printf("Hello World.\r\n");
+    /* Application tasks and logic start here. */
+}
+```
+
+For a new product, copy the closest application example, give it a unique `PROJECT_NAME`, update `proj_config.mk`, and keep product-specific sources in the application's own component directory. Avoid editing common platform components unless the change is intended for every application.
+
+## Flashing
+
+After connecting the correct board and serial port, run from the selected application directory:
+
+```bash
 make flash p=/dev/ttyUSB0 b=921600
 ```
-## Step 5. Other
-In addition, you can use this command to view help.
-```
-make help
-```
-> Your configuration chipname is Ai-Thinker Ai-WB2 Wi-Fi&BLE Module
-> 
->Welcome to Ai-WB2 SDK build system. make targets:
->
-> - "make all" - Build app, components
-> - "make clean" - Remove all app components output
-> - "make flash" - Build and download firmware 
-> - "make flash-only" - Only download firmware
-> - "make eflash" - Use the flash after erasing it
-> - "make erase_flash" - Erase all internal contents of flash
-> - "make list-components" - List all components in the project
-> - "make [component name]" - build a component as a library
 
+Erase and flash only when the target board, port, and power state have been confirmed:
 
-Note: After erasing the flash, you need to use this command to download it,but always press the BURN button,then press the EN button.next,release all keys.
+```bash
+make eflash p=/dev/ttyUSB0 b=921600
 ```
-make eflash
+
+Flashing accesses physical hardware and is not part of the automated build validation recorded in this repository.
+
+## Troubleshooting
+
+### The compiler reports `Permission denied`
+
+Run the `find ... chmod` command in [Prepare the toolchain](#prepare-the-toolchain). If the repository is on a Windows-mounted WSL2 drive and permissions still do not persist, copy it into the WSL2 Linux file system.
+
+### A toolchain or flashing-tool directory is empty
+
+Initialize the submodules:
+
+```bash
+git submodule update --init --recursive
 ```
+
+### Make reports an invalid `BL60X_SDK_PATH`
+
+Run `make` from an application directory. If overriding `BL60X_SDK_PATH`, pass an absolute Unix-style path without a Windows drive colon.
+
+### The build succeeds but the board does not boot
+
+A successful link does not validate hardware. Confirm the exact module variant, power supply, boot straps, serial wiring, baud rate, Flash layout, and boot log before changing SDK code.
+
+## Known limitations
+
+- The verified `helloworld` clean build currently emits 11 compiler warnings; see the build-validation record;
+- The validation covers compilation and linking only, not flashing, RF behavior, Wi-Fi/BLE interoperability, peripheral wiring, or every application example;
+- Toolchains and the flashing tool are pinned submodules hosted separately and must be available during a fresh recursive clone;
+- Some applications may require additional hardware, credentials, or service configuration. Never commit private keys, Wi-Fi passwords, tokens, or production endpoints.
+
+## Contributing
+
+Before opening a pull request:
+
+- Identify the application and module variant affected;
+- Run at least one clean build and include the command, host environment, toolchain version, warning/error count, and output names;
+- For shared-component changes, build more than one representative application when practical;
+- For hardware changes, include wiring, board revision, serial logs, and reproducible test steps;
+- Do not commit `build_out/`, credentials, generated secrets, or local IDE settings.
+
+## License
+
+The repository is distributed under the [Apache License 2.0](LICENSE). Third-party components and submodules may contain their own license terms; review those terms when redistributing a product.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,189 @@
+<div align="center">
+
+# Ai-Thinker Ai-WB2 开发框架
+
+</div>
+
+[![English](https://img.shields.io/badge/English-README-blue)](README.md)
+
+## 项目介绍
+
+Ai-Thinker Ai-WB2 开发框架是面向 Ai-WB2 无线模组的嵌入式 SDK，基于博流智能 BL IoT SDK。仓库主要支持 BL602 Wi-Fi/BLE RISC-V 平台，同时包含 BL70x 相关平台组件和示例，并提供芯片支持、FreeRTOS、外设与网络组件、Make 构建系统、固定版本的交叉工具链、烧录工具和应用示例。
+
+> 本仓库是固件源码，不是桌面应用程序。可在 Linux 或 WSL2 中编译；烧录和功能验收需要兼容的 Ai-WB2 开发板及正确接线。
+
+## 支持范围
+
+- 主要模组：Ai-Thinker Ai-WB2；
+- 主要芯片：BL602，仓库中也包含 BL70x 相关平台内容；
+- CPU 架构：RISC-V；
+- 操作系统：FreeRTOS；
+- 接口与中间件：GPIO、UART、I²C、SPI、PWM、ADC、Wi-Fi、BLE、TCP/IP、文件系统、密码学及各应用按需选择的其他组件；
+- 构建系统：GNU Make，以及仓库固定版本的 Linux、macOS、MSYS RISC-V 工具链。
+
+`applications/` 下共有 241 个应用 Makefile，按入门、外设、Wi-Fi、蓝牙、协议、安全、存储、系统和 IoT 方案分类。它们是相互独立的工程；构建 `helloworld` 可以验证公共 BL602 构建路径，但不能代表所有示例和硬件功能都已验证。
+
+源码证据详见 [代码入口](docs/CODE_ENTRY.zh.md)、[架构说明](docs/ARCHITECTURE.zh.md) 和 [构建验证](docs/BUILD_VALIDATION.zh.md)。
+
+## 快速开始
+
+在 Ubuntu 或 WSL2 中执行：
+
+```bash
+sudo apt update
+sudo apt install build-essential git python3 python3-pip
+
+git clone --recurse-submodules https://github.com/Ai-Thinker-Open/Ai-Thinker-WB2.git
+cd Ai-Thinker-WB2
+
+find toolchain/riscv/Linux/bin toolchain/riscv/Linux/libexec \
+  -type f -exec chmod u+x {} +
+
+cd applications/get-started/helloworld
+make -j8
+```
+
+主要产物位于 `applications/get-started/helloworld/build_out/`。
+
+## 环境准备
+
+Debian 或 Ubuntu 安装：
+
+```bash
+sudo apt install build-essential git python3 python3-pip
+```
+
+Arch Linux 安装：
+
+```bash
+sudo pacman -S base-devel git python python-pip
+```
+
+使用区分大小写的 Linux 文件系统可以获得最快且更稳定的构建。WSL2 也可以直接从 Windows 盘构建，但放在 WSL2 原生目录中可避免 Windows 时间戳和文件权限差异。
+
+## 获取源码
+
+拉取所有固定版本的工具链与烧录工具子模块：
+
+```bash
+git clone --recurse-submodules https://github.com/Ai-Thinker-Open/Ai-Thinker-WB2.git
+cd Ai-Thinker-WB2
+git submodule status --recursive
+```
+
+如果普通 clone 时未包含子模块：
+
+```bash
+git submodule update --init --recursive
+```
+
+需要可复现构建时，不要随意把子模块切到其他分支。主仓库记录了每个工具链和烧录工具依赖应使用的 Commit。
+
+## 准备工具链
+
+Windows 挂载盘中的 Git 工作树可能不会保存 Unix 执行权限。在 Linux 或 WSL2 中执行：
+
+```bash
+find toolchain/riscv/Linux/bin toolchain/riscv/Linux/libexec \
+  -type f -exec chmod u+x {} +
+```
+
+该命令只修改本地执行权限，不会修改源码内容，也不会改变工具链固定 Commit。
+
+## 编译应用
+
+每个应用目录都有自己的 `Makefile`、`proj_config.mk`、应用组件和可选本地组件。官方 `helloworld` 示例的构建命令为：
+
+```bash
+cd applications/get-started/helloworld
+make clean
+make -j8
+```
+
+常用目标：
+
+```bash
+make help
+make list-components
+make clean
+```
+
+`helloworld` 主要产物：
+
+- `build_out/helloworld.elf`：包含符号的链接固件；
+- `build_out/helloworld.bin`：应用二进制；
+- `build_out/helloworld.flash.bin`：烧录二进制；
+- `build_out/helloworld.map`：链接 Map。
+
+## 从示例开始开发
+
+`helloworld` 的应用入口位于 `applications/get-started/helloworld/helloworld/main.c`：
+
+```c
+void main(void)
+{
+    printf("Hello World.\r\n");
+    /* 在这里启动应用任务和业务逻辑。 */
+}
+```
+
+新产品可以复制最接近需求的应用示例，设置唯一的 `PROJECT_NAME`，更新 `proj_config.mk`，并把产品源码放在应用自己的组件目录中。除非改动确实需要影响所有应用，否则应避免直接修改公共平台组件。
+
+## 烧录
+
+连接并确认正确的开发板和串口后，在所选应用目录执行：
+
+```bash
+make flash p=/dev/ttyUSB0 b=921600
+```
+
+只有在确认目标板、串口和供电状态后才执行擦除烧录：
+
+```bash
+make eflash p=/dev/ttyUSB0 b=921600
+```
+
+烧录会访问物理硬件，不属于本仓库自动构建验证的范围。
+
+## 常见问题
+
+### 编译器提示 `Permission denied`
+
+重新执行[准备工具链](#准备工具链)中的 `find ... chmod` 命令。如果仓库位于 WSL2 的 Windows 挂载盘且权限仍无法保存，请复制到 WSL2 Linux 文件系统中构建。
+
+### 工具链或烧录工具目录为空
+
+初始化子模块：
+
+```bash
+git submodule update --init --recursive
+```
+
+### Make 提示 `BL60X_SDK_PATH` 无效
+
+请从具体应用目录运行 `make`。如果手动覆盖 `BL60X_SDK_PATH`，应使用不带 Windows 盘符冒号的 Unix 绝对路径。
+
+### 编译成功但开发板不能启动
+
+链接成功不能验证硬件。修改 SDK 前请先确认模组型号、供电、启动脚、串口接线、波特率、Flash 布局和启动日志。
+
+## 已知限制
+
+- 已验证的 `helloworld` 干净构建当前存在 11 条编译告警，详见构建验证；
+- 验证只覆盖编译和链接，不包含烧录、射频效果、Wi-Fi/BLE 互操作、外设接线或所有应用示例；
+- 工具链和烧录工具是托管在其他服务上的固定子模块，全新递归 clone 时必须能够访问这些地址；
+- 部分应用需要额外硬件、凭据或服务配置。不要提交私钥、Wi-Fi 密码、Token 或生产环境地址。
+
+## 贡献说明
+
+提交 Pull Request 前：
+
+- 说明受影响的应用和模组版本；
+- 至少执行一次干净构建，并提供命令、主机环境、工具链版本、warning/error 数量和产物名称；
+- 修改公共组件时，应尽量构建多个代表性应用；
+- 涉及硬件时，提供接线、板卡版本、串口日志和可复现步骤；
+- 不要提交 `build_out/`、凭据、生成的密钥或本地 IDE 配置。
+
+## 许可证
+
+本仓库采用 [Apache License 2.0](LICENSE)。第三方组件和子模块可能有自己的许可证，产品再分发前应同时检查相应条款。

--- a/audit/technical-evidence.json
+++ b/audit/technical-evidence.json
@@ -1,0 +1,125 @@
+{
+  "schema_version": "1.0",
+  "rules_version": "2.0-sdk-technical",
+  "repositories": {
+    "Ai-Thinker-Open/Ai-Thinker-WB2": {
+      "code_entry": {
+        "status": "verified",
+        "entry_points": [
+          "components/platform/soc/bl602/bl602/evb/src/boot/gcc/start.S:150:call bfl_main",
+          "components/platform/soc/bl602/bl602/bfl_main.c:304:bfl_main",
+          "components/platform/soc/bl602/bl602/bfl_main.c:173:app_main_entry",
+          "applications/get-started/helloworld/helloworld/main.c:16:main"
+        ],
+        "evidence": [
+          "applications/get-started/helloworld/Makefile selects the helloworld component and common BL602 components",
+          "applications/get-started/helloworld/helloworld/bouffalo.mk participates in the component build",
+          "components/platform/soc/bl602/bl602/bfl_main.c bridges platform startup to the application main task",
+          "applications/get-started/helloworld/build_out/helloworld.map",
+          "RISC-V nm confirms app_main_entry, main and vTaskStartScheduler in helloworld.elf"
+        ],
+        "build_linked": true
+      },
+      "architecture": {
+        "status": "verified",
+        "modules": [
+          "independent application projects",
+          "Make-based component build orchestration",
+          "BL602 and BL70x platform support",
+          "FreeRTOS and OS adaptation",
+          "network and wireless protocol components",
+          "system services and middleware",
+          "file-system and security components",
+          "pinned RISC-V toolchains",
+          "flashing and debugging tools"
+        ],
+        "evidence": [
+          "applications/get-started/helloworld/Makefile",
+          "applications/get-started/helloworld/proj_config.mk",
+          "applications/get-started/helloworld/helloworld/bouffalo.mk",
+          "make_scripts_riscv/project.mk",
+          "make_scripts_riscv/component_wrapper.mk",
+          "components/platform/soc/bl602/bl602/evb/src/boot/gcc/start.S",
+          "components/platform/soc/bl602/bl602/bfl_main.c",
+          "docs/ARCHITECTURE.md"
+        ],
+        "init_flow": [
+          "BL602 startup assembly",
+          "bfl_main",
+          "chip, heap, UART, security, boot and board initialization",
+          "aos_loop_proc task creation",
+          "FreeRTOS scheduler start",
+          "VFS and event-loop initialization",
+          "app_main_entry task creation",
+          "application main"
+        ]
+      },
+      "build": {
+        "status": "passed",
+        "clean_builds": 2,
+        "command": "cd applications/get-started/helloworld && make clean && make -j8",
+        "commit": "2420da77a4e8b03df06f3d747224a62e54113a20",
+        "repository_base_commit": "2420da77a4e8b03df06f3d747224a62e54113a20",
+        "source_tree": "ca6e3323287ca6e69a63313b8c40e8ba5e7f7ea6",
+        "submodules": {
+          "toolchain/riscv/Linux": "fbff0015ed1657fd5677283b02eab250ab49d43a"
+        },
+        "log": "docs/build-logs/Ai-Thinker-WB2-helloworld-clean-build-2.log",
+        "environment": {
+          "os": "Ubuntu 22.04.5 LTS on WSL2",
+          "kernel": "6.18.33.2-microsoft-standard-WSL2",
+          "make": "GNU Make 4.3",
+          "compiler": "SiFive GCC-Metal 10.2.0-2020.12.8"
+        },
+        "runs": [
+          {
+            "clean_build": 1,
+            "elapsed_seconds": 5.37,
+            "warnings": 11,
+            "errors": 0,
+            "log": "docs/build-logs/Ai-Thinker-WB2-helloworld-clean-build-1.log"
+          },
+          {
+            "clean_build": 2,
+            "elapsed_seconds": 5.18,
+            "warnings": 11,
+            "errors": 0,
+            "log": "docs/build-logs/Ai-Thinker-WB2-helloworld-clean-build-2.log"
+          }
+        ],
+        "artifacts": [
+          {
+            "path": "applications/get-started/helloworld/build_out/helloworld.elf",
+            "size": 1103168,
+            "sha256": "a7a448b516362cbbb6db32636f57669dd998314c75e2cd388adb1e1e9a961eb0"
+          },
+          {
+            "path": "applications/get-started/helloworld/build_out/helloworld.bin",
+            "size": 68056,
+            "sha256": "0328029d45c97ce638a494d80f48ac3605eb1d6aa9bd3d1bee2d9c5c55fd364a"
+          },
+          {
+            "path": "applications/get-started/helloworld/build_out/helloworld.flash.bin",
+            "size": 68056,
+            "sha256": "0328029d45c97ce638a494d80f48ac3605eb1d6aa9bd3d1bee2d9c5c55fd364a"
+          },
+          {
+            "path": "applications/get-started/helloworld/build_out/helloworld.map",
+            "size": 1027560,
+            "sha256": "e485615fc6c9d6db9874b65ac7e7a4f91729b773d6fe3c22e17d09a1ee531737"
+          }
+        ],
+        "errors": 0,
+        "warnings": 11,
+        "warning_breakdown": {
+          "blog_testc_overflow": 5,
+          "hal_sys_array_bounds": 5,
+          "hosal_uart_unused_variable": 1
+        },
+        "hardware_verified": false,
+        "validated_target": "applications/get-started/helloworld",
+        "application_makefiles_in_repository": 241
+      }
+    }
+  }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,68 @@
+<div align="center">
+
+# Architecture
+
+</div>
+
+[![中文](https://img.shields.io/badge/中文-README-blue)](ARCHITECTURE.zh.md)
+
+## Repository layers
+
+| Layer | Path | Responsibility |
+| --- | --- | --- |
+| Application projects | `applications/` | Independent firmware projects with a project Makefile, configuration, application component, and optional local components |
+| Build orchestration | `make_scripts_riscv/` | Component discovery, per-component compilation, static-library creation, linking, binary conversion, clean, help, and flashing targets |
+| SoC and board platform | `components/platform/` | BL602/BL70x startup, standard drivers, hardware abstraction, board configuration, and platform entry code |
+| Operating system | `components/os/` | FreeRTOS and OS adaptation layers selected by each project |
+| Networking | `components/network/` | Wi-Fi, BLE, TCP/IP, HTTP, MQTT, provisioning, and related protocol components |
+| Services and middleware | `components/stage/`, `components/sys/`, `components/utils/` | Logging, CLI, event loops, storage helpers, OTA, diagnostics, and reusable utilities |
+| File systems and security | `components/fs/`, `components/security/` | VFS/file-system components and cryptographic libraries or adapters |
+| Fixed toolchains | `toolchain/riscv/` | Gitlink-pinned RISC-V compiler suites for Linux, macOS, and MSYS |
+| Development tools | `tools/` | Flashing, debugging, CI, image, and support utilities |
+
+The exact component set is application-specific. A project declares `INCLUDE_COMPONENTS` in its Makefile; `make_scripts_riscv/project.mk` finds matching `bouffalo.mk` files and builds only the selected component graph.
+
+## Build relationships
+
+```text
+application/Makefile
+  ├─ proj_config.mk (feature and board configuration)
+  ├─ application component/bouffalo.mk
+  └─ make_scripts_riscv/project.mk
+       ├─ discover selected component bouffalo.mk files
+       ├─ compile each component into lib<component>.a
+       ├─ link <project>.elf and generate <project>.map
+       └─ objcopy <project>.bin / <project>.flash.bin
+```
+
+For `applications/get-started/helloworld`, the project selects the BL602 platform, FreeRTOS, newlibc, HOSAL, mbedTLS, lwIP, VFS, event-loop, logging, CLI, core-dump, and application components. This is the representative common path used for the recorded build validation.
+
+## BL602 runtime flow
+
+```text
+components/platform/soc/bl602/bl602/evb/src/boot/gcc/start.S
+  → bfl_main()
+  → early chip, UART, heap, security, boot, and board initialization
+  → create aos_loop_proc task
+  → vTaskStartScheduler()
+  → initialize VFS / event-loop services selected by proj_config.mk
+  → create app_main_entry task
+  → call the application's main()
+```
+
+The application-defined `main()` is not the reset handler. BL602 startup assembly calls the platform `bfl_main()`, which initializes shared services and starts FreeRTOS. The internal `app_main_entry()` task then invokes the `main()` supplied by the selected application component.
+
+## Extension boundaries
+
+- Product logic belongs in an application component under `applications/`;
+- Feature selection belongs in the application's `proj_config.mk` and Makefile;
+- Reusable drivers or middleware can be implemented as components with their own `bouffalo.mk`;
+- Common platform changes under `components/platform/` affect many applications and require broader regression builds;
+- Toolchain and flashing-tool Gitlinks should remain pinned unless a separately reviewed dependency upgrade is intended.
+
+## Verification boundary
+
+- Makefiles, component archives, the linker map, and ELF symbols demonstrate component selection and linking;
+- A `helloworld` build does not prove that every one of the 241 application Makefiles builds successfully;
+- Static compilation cannot validate board wiring, RF behavior, serial timing, Flash programming, or Wi-Fi/BLE interoperability;
+- Third-party component behavior and separately hosted submodules remain subject to their own source and license review.

--- a/docs/ARCHITECTURE.zh.md
+++ b/docs/ARCHITECTURE.zh.md
@@ -1,0 +1,68 @@
+<div align="center">
+
+# 架构说明
+
+</div>
+
+[![English](https://img.shields.io/badge/English-README-blue)](ARCHITECTURE.md)
+
+## 仓库分层
+
+| 层级 | 路径 | 职责 |
+| --- | --- | --- |
+| 应用工程 | `applications/` | 相互独立的固件工程，包含项目 Makefile、配置、应用组件和可选本地组件 |
+| 构建编排 | `make_scripts_riscv/` | 组件发现、逐组件编译、静态库生成、链接、二进制转换、清理、帮助和烧录目标 |
+| SoC 与开发板平台 | `components/platform/` | BL602/BL70x 启动、标准驱动、硬件抽象、开发板配置和平台入口代码 |
+| 操作系统 | `components/os/` | 各项目按需选择的 FreeRTOS 和操作系统适配层 |
+| 网络 | `components/network/` | Wi-Fi、BLE、TCP/IP、HTTP、MQTT、配网及相关协议组件 |
+| 服务与中间件 | `components/stage/`、`components/sys/`、`components/utils/` | 日志、CLI、事件循环、存储辅助、OTA、诊断和通用工具 |
+| 文件系统与安全 | `components/fs/`、`components/security/` | VFS/文件系统组件，以及密码学库或适配层 |
+| 固定工具链 | `toolchain/riscv/` | 通过 Gitlink 固定版本的 Linux、macOS、MSYS RISC-V 编译器套件 |
+| 开发工具 | `tools/` | 烧录、调试、CI、镜像和辅助工具 |
+
+实际使用的组件集合由应用决定。项目 Makefile 通过 `INCLUDE_COMPONENTS` 声明组件，`make_scripts_riscv/project.mk` 查找匹配的 `bouffalo.mk`，并只构建被选中的组件图。
+
+## 构建关系
+
+```text
+application/Makefile
+  ├─ proj_config.mk（功能与开发板配置）
+  ├─ 应用组件/bouffalo.mk
+  └─ make_scripts_riscv/project.mk
+       ├─ 查找所选组件的 bouffalo.mk
+       ├─ 把每个组件编译为 lib<component>.a
+       ├─ 链接 <project>.elf 并生成 <project>.map
+       └─ 转换 <project>.bin / <project>.flash.bin
+```
+
+`applications/get-started/helloworld` 选择 BL602 平台、FreeRTOS、newlibc、HOSAL、mbedTLS、lwIP、VFS、事件循环、日志、CLI、Core Dump 和应用组件。本次构建验证以它作为公共构建路径的代表。
+
+## BL602 运行时流程
+
+```text
+components/platform/soc/bl602/bl602/evb/src/boot/gcc/start.S
+  → bfl_main()
+  → 芯片、UART、堆、安全、Boot 与开发板早期初始化
+  → 创建 aos_loop_proc 任务
+  → vTaskStartScheduler()
+  → 初始化 proj_config.mk 选择的 VFS / 事件循环服务
+  → 创建 app_main_entry 任务
+  → 调用应用自己的 main()
+```
+
+应用定义的 `main()` 不是复位入口。BL602 启动汇编先调用平台 `bfl_main()`，完成公共服务初始化并启动 FreeRTOS；内部 `app_main_entry()` 任务随后调用所选应用组件提供的 `main()`。
+
+## 扩展边界
+
+- 产品逻辑应放在 `applications/` 下的应用组件中；
+- 功能开关应放在应用的 `proj_config.mk` 和 Makefile 中；
+- 可复用驱动或中间件可以实现为带独立 `bouffalo.mk` 的组件；
+- `components/platform/` 下的公共平台修改会影响多个应用，需要更广泛的回归构建；
+- 除非要进行单独审核的依赖升级，否则工具链和烧录工具 Gitlink 应保持固定。
+
+## 验证边界
+
+- Makefile、组件静态库、链接 Map 和 ELF 符号可以证明组件被选择并链接；
+- 构建 `helloworld` 不能证明 241 个应用 Makefile 全部构建成功；
+- 静态编译不能验证开发板接线、射频效果、串口时序、Flash 烧录或 Wi-Fi/BLE 互操作；
+- 第三方组件及单独托管的子模块仍需依据其自身源码和许可证进行审核。

--- a/docs/BUILD_VALIDATION.md
+++ b/docs/BUILD_VALIDATION.md
@@ -1,0 +1,90 @@
+<div align="center">
+
+# Build Validation
+
+</div>
+
+[![中文](https://img.shields.io/badge/中文-README-blue)](BUILD_VALIDATION.zh.md)
+
+## Validation target
+
+The repository is a multi-application SDK. The recorded build validates the official BL602 getting-started project:
+
+```text
+applications/get-started/helloworld
+```
+
+This target exercises the common Make framework, pinned Linux RISC-V toolchain, BL602 platform, FreeRTOS, HOSAL, mbedTLS, lwIP, VFS, logging, CLI, utilities, and the application component. It does not claim that all 241 application Makefiles or their hardware dependencies were tested.
+
+## Reproducible commands
+
+```bash
+git submodule update --init --recursive
+find toolchain/riscv/Linux/bin toolchain/riscv/Linux/libexec \
+  -type f -exec chmod u+x {} +
+
+cd applications/get-started/helloworld
+make clean
+make -j8
+```
+
+Run `make clean` before each recorded build and preserve the complete output. For WSL2, a native Linux path is recommended to avoid Windows timestamp and file-mode differences.
+
+## Success criteria
+
+- The build command exits with status 0;
+- The compiler reports no errors;
+- `helloworld.elf`, `helloworld.bin`, `helloworld.flash.bin`, and `helloworld.map` exist and are non-empty;
+- The final ELF contains `main`, `app_main_entry`, and `vTaskStartScheduler`;
+- The source commit, source tree, toolchain Gitlink, environment, warning count, output sizes, and SHA-256 hashes are recorded.
+
+## Verified results
+
+- Source commit: `2420da77a4e8b03df06f3d747224a62e54113a20`;
+- Source tree: `ca6e3323287ca6e69a63313b8c40e8ba5e7f7ea6`;
+- Local rollback tag: `audit-baseline-before-health-improvements`;
+- Linux toolchain Gitlink: `fbff0015ed1657fd5677283b02eab250ab49d43a`;
+- Build command: `cd applications/get-started/helloworld && make clean && make -j8`;
+- Environment: Ubuntu 22.04.5 LTS on WSL2, Linux `6.18.33.2-microsoft-standard-WSL2`;
+- Build tools: GNU Make 4.3, SiFive GCC-Metal 10.2.0-2020.12.8;
+- First clean build: passed in 5.37 seconds, 11 compiler warnings, 0 errors;
+- Second clean build: passed in 5.18 seconds, 11 compiler warnings, 0 errors;
+- Logs: [first clean build](build-logs/Ai-Thinker-WB2-helloworld-clean-build-1.log), [second clean build](build-logs/Ai-Thinker-WB2-helloworld-clean-build-2.log).
+
+The warning count was identical in both runs:
+
+- 5 `-Woverflow` warnings in `components/stage/blog_testc/blog_testc2_full.c`;
+- 5 `-Warray-bounds` warnings in `components/platform/hosal/bl602_hal/hal_sys.c`;
+- 1 `-Wunused-but-set-variable` warning in `components/platform/hosal/bl602_hal/hosal_uart.c`.
+
+The validation records these existing warnings rather than suppressing or changing shared platform code without a separate regression review.
+
+## Second-build outputs
+
+| Output | Size in bytes | SHA-256 |
+| --- | ---: | --- |
+| `applications/get-started/helloworld/build_out/helloworld.elf` | 1,103,168 | `a7a448b516362cbbb6db32636f57669dd998314c75e2cd388adb1e1e9a961eb0` |
+| `applications/get-started/helloworld/build_out/helloworld.bin` | 68,056 | `0328029d45c97ce638a494d80f48ac3605eb1d6aa9bd3d1bee2d9c5c55fd364a` |
+| `applications/get-started/helloworld/build_out/helloworld.flash.bin` | 68,056 | `0328029d45c97ce638a494d80f48ac3605eb1d6aa9bd3d1bee2d9c5c55fd364a` |
+| `applications/get-started/helloworld/build_out/helloworld.map` | 1,027,560 | `e485615fc6c9d6db9874b65ac7e7a4f91729b773d6fe3c22e17d09a1ee531737` |
+
+The firmware embeds compile date and time, so ELF or binary hashes from a later clean build may legitimately differ. Hashes above identify the recorded second-run outputs, not a reproducible-build guarantee.
+
+## ELF entry symbols
+
+```text
+23000c50 t app_main_entry
+23000c00 T main
+2300365c T vTaskStartScheduler
+```
+
+## Current validation boundary
+
+The results cover compilation and linking of one representative BL602 application only. They do not include:
+
+- `make flash` or physical Flash erase/programming;
+- Ai-WB2 boot logs or long-duration operation;
+- GPIO, UART, I²C, SPI, PWM, ADC, Wi-Fi, BLE, or network interoperability tests;
+- BL70x application builds;
+- A full matrix build of every application;
+- Security review of third-party components or separately hosted submodules.

--- a/docs/BUILD_VALIDATION.zh.md
+++ b/docs/BUILD_VALIDATION.zh.md
@@ -1,0 +1,90 @@
+<div align="center">
+
+# 构建验证
+
+</div>
+
+[![English](https://img.shields.io/badge/English-README-blue)](BUILD_VALIDATION.md)
+
+## 验证目标
+
+本仓库是多应用 SDK。本次构建验证选择官方 BL602 入门工程：
+
+```text
+applications/get-started/helloworld
+```
+
+该目标会经过公共 Make 框架、固定 Linux RISC-V 工具链、BL602 平台、FreeRTOS、HOSAL、mbedTLS、lwIP、VFS、日志、CLI、工具组件和应用组件。它不代表 241 个应用 Makefile 及其硬件依赖已全部测试。
+
+## 可复现命令
+
+```bash
+git submodule update --init --recursive
+find toolchain/riscv/Linux/bin toolchain/riscv/Linux/libexec \
+  -type f -exec chmod u+x {} +
+
+cd applications/get-started/helloworld
+make clean
+make -j8
+```
+
+每次记录构建前执行 `make clean`，并保存完整输出。WSL2 建议使用 Linux 原生路径，以避免 Windows 时间戳和文件权限差异。
+
+## 成功判定
+
+- 构建命令退出码为 0；
+- 编译器没有报告 error；
+- `helloworld.elf`、`helloworld.bin`、`helloworld.flash.bin` 和 `helloworld.map` 存在且非空；
+- 最终 ELF 包含 `main`、`app_main_entry` 和 `vTaskStartScheduler`；
+- 记录源码 Commit、源码 Tree、工具链 Gitlink、环境、告警数量、产物大小和 SHA-256。
+
+## 已验证结果
+
+- 源码 Commit：`2420da77a4e8b03df06f3d747224a62e54113a20`；
+- 源码 Tree：`ca6e3323287ca6e69a63313b8c40e8ba5e7f7ea6`；
+- 本地回退标签：`audit-baseline-before-health-improvements`；
+- Linux 工具链 Gitlink：`fbff0015ed1657fd5677283b02eab250ab49d43a`；
+- 构建命令：`cd applications/get-started/helloworld && make clean && make -j8`；
+- 环境：Ubuntu 22.04.5 LTS on WSL2，Linux `6.18.33.2-microsoft-standard-WSL2`；
+- 构建工具：GNU Make 4.3，SiFive GCC-Metal 10.2.0-2020.12.8；
+- 第一次干净构建：通过，5.37 秒，11 条编译告警，0 errors；
+- 第二次干净构建：通过，5.18 秒，11 条编译告警，0 errors；
+- 日志：[第一次干净构建](build-logs/Ai-Thinker-WB2-helloworld-clean-build-1.log)、[第二次干净构建](build-logs/Ai-Thinker-WB2-helloworld-clean-build-2.log)。
+
+两次构建的告警数量一致：
+
+- `components/stage/blog_testc/blog_testc2_full.c` 中 5 条 `-Woverflow`；
+- `components/platform/hosal/bl602_hal/hal_sys.c` 中 5 条 `-Warray-bounds`；
+- `components/platform/hosal/bl602_hal/hosal_uart.c` 中 1 条 `-Wunused-but-set-variable`。
+
+本次只记录这些既有告警，没有在缺少单独回归审核的情况下通过抑制告警或修改公共平台代码来提高分数。
+
+## 第二次构建产物
+
+| 产物 | 字节数 | SHA-256 |
+| --- | ---: | --- |
+| `applications/get-started/helloworld/build_out/helloworld.elf` | 1,103,168 | `a7a448b516362cbbb6db32636f57669dd998314c75e2cd388adb1e1e9a961eb0` |
+| `applications/get-started/helloworld/build_out/helloworld.bin` | 68,056 | `0328029d45c97ce638a494d80f48ac3605eb1d6aa9bd3d1bee2d9c5c55fd364a` |
+| `applications/get-started/helloworld/build_out/helloworld.flash.bin` | 68,056 | `0328029d45c97ce638a494d80f48ac3605eb1d6aa9bd3d1bee2d9c5c55fd364a` |
+| `applications/get-started/helloworld/build_out/helloworld.map` | 1,027,560 | `e485615fc6c9d6db9874b65ac7e7a4f91729b773d6fe3c22e17d09a1ee531737` |
+
+固件会写入编译日期和时间，因此以后再次干净构建得到的 ELF 或二进制哈希可能合理地不同。上表哈希只用于标识第二次记录的产物，不表示已经实现可复现二进制构建。
+
+## ELF 入口符号
+
+```text
+23000c50 t app_main_entry
+23000c00 T main
+2300365c T vTaskStartScheduler
+```
+
+## 当前验证边界
+
+结果只覆盖一个代表性 BL602 应用的编译和链接，不包含：
+
+- `make flash` 或物理 Flash 擦除、烧录；
+- Ai-WB2 启动日志或长时间运行；
+- GPIO、UART、I²C、SPI、PWM、ADC、Wi-Fi、BLE 或网络互操作测试；
+- BL70x 应用构建；
+- 所有应用的完整矩阵构建；
+- 第三方组件或单独托管子模块的安全审查。

--- a/docs/CODE_ENTRY.md
+++ b/docs/CODE_ENTRY.md
@@ -1,0 +1,66 @@
+<div align="center">
+
+# Code Entry
+
+</div>
+
+[![中文](https://img.shields.io/badge/中文-README-blue)](CODE_ENTRY.zh.md)
+
+## Application entry model
+
+Ai-Thinker-WB2 is a multi-application SDK, so there is no single product-level `main()` for the whole repository. Each project selects an application component whose source supplies `main()`. The representative getting-started entry is:
+
+```text
+applications/get-started/helloworld/helloworld/main.c:main
+```
+
+Its project Makefile sets `PROJECT_NAME := helloworld`, adds `helloworld` to `INCLUDE_COMPONENTS`, and includes `make_scripts_riscv/project.mk`. The application's `bouffalo.mk` then makes `main.c` part of `libhelloworld.a`, which is linked into `helloworld.elf`.
+
+## Platform-to-application call path
+
+The BL602 startup and application-entry sequence is:
+
+1. `components/platform/soc/bl602/bl602/evb/src/boot/gcc/start.S` calls `bfl_main`;
+2. `components/platform/soc/bl602/bl602/bfl_main.c:bfl_main` performs early platform setup, creates the event-loop task, and starts FreeRTOS;
+3. `aos_loop_proc` initializes enabled shared services and creates `app_main_entry`;
+4. `app_main_entry` calls the application-provided `main()`;
+5. The `helloworld` implementation prints its message, delays through a restart countdown, and requests a power-on reset.
+
+Configuration macros in `applications/get-started/helloworld/proj_config.mk` control the application task stack, priority, VFS, logging, Wi-Fi/BLE options, and other selected services.
+
+## Representative application code
+
+```c
+void main(void)
+{
+    printf("Hello World.\r\n");
+    for (int i = 10; i >= 0; i--)
+    {
+        printf("Restarting in %d seconds...\r\n", i);
+        vTaskDelay(1000 / portTICK_PERIOD_MS);
+    }
+    bl_sys_reset_por();
+}
+```
+
+Other examples define their own entry and configuration. When selecting a different application, review that application's Makefile, `proj_config.mk`, component `bouffalo.mk`, and `main.c` together.
+
+## Build-linked evidence
+
+After building `helloworld`, run:
+
+```bash
+toolchain/riscv/Linux/bin/riscv64-unknown-elf-nm \
+  applications/get-started/helloworld/build_out/helloworld.elf \
+  | grep -E ' app_main_entry$| main$| vTaskStartScheduler$'
+```
+
+The verified ELF contains:
+
+```text
+23000c50 t app_main_entry
+23000c00 T main
+2300365c T vTaskStartScheduler
+```
+
+This proves that the platform task bridge, application entry, and scheduler were linked into the final representative firmware. Exact commits and output hashes are recorded in [Build Validation](BUILD_VALIDATION.md).

--- a/docs/CODE_ENTRY.zh.md
+++ b/docs/CODE_ENTRY.zh.md
@@ -1,0 +1,66 @@
+<div align="center">
+
+# 代码入口
+
+</div>
+
+[![English](https://img.shields.io/badge/English-README-blue)](CODE_ENTRY.md)
+
+## 应用入口模型
+
+Ai-Thinker-WB2 是多应用 SDK，因此整个仓库不存在唯一的产品级 `main()`。每个工程会选择一个提供 `main()` 的应用组件。代表性的入门入口为：
+
+```text
+applications/get-started/helloworld/helloworld/main.c:main
+```
+
+项目 Makefile 设置 `PROJECT_NAME := helloworld`，把 `helloworld` 加入 `INCLUDE_COMPONENTS`，并包含 `make_scripts_riscv/project.mk`。应用的 `bouffalo.mk` 随后使 `main.c` 参与 `libhelloworld.a` 构建，并最终链接进 `helloworld.elf`。
+
+## 平台到应用的调用路径
+
+BL602 启动与应用入口顺序为：
+
+1. `components/platform/soc/bl602/bl602/evb/src/boot/gcc/start.S` 调用 `bfl_main`；
+2. `components/platform/soc/bl602/bl602/bfl_main.c:bfl_main` 完成平台早期初始化，创建事件循环任务并启动 FreeRTOS；
+3. `aos_loop_proc` 初始化已启用的公共服务，并创建 `app_main_entry`；
+4. `app_main_entry` 调用应用提供的 `main()`；
+5. `helloworld` 实现打印信息，执行重启倒计时，并请求上电复位。
+
+`applications/get-started/helloworld/proj_config.mk` 中的宏控制应用任务栈、优先级、VFS、日志、Wi-Fi/BLE 选项及其他被选服务。
+
+## 代表性应用代码
+
+```c
+void main(void)
+{
+    printf("Hello World.\r\n");
+    for (int i = 10; i >= 0; i--)
+    {
+        printf("Restarting in %d seconds...\r\n", i);
+        vTaskDelay(1000 / portTICK_PERIOD_MS);
+    }
+    bl_sys_reset_por();
+}
+```
+
+其他示例有各自的入口和配置。切换应用时，应同时检查该应用的 Makefile、`proj_config.mk`、组件 `bouffalo.mk` 和 `main.c`。
+
+## 构建链接证据
+
+构建 `helloworld` 后执行：
+
+```bash
+toolchain/riscv/Linux/bin/riscv64-unknown-elf-nm \
+  applications/get-started/helloworld/build_out/helloworld.elf \
+  | grep -E ' app_main_entry$| main$| vTaskStartScheduler$'
+```
+
+已验证 ELF 包含：
+
+```text
+23000c50 t app_main_entry
+23000c00 T main
+2300365c T vTaskStartScheduler
+```
+
+这证明平台任务桥、应用入口和调度器已链接进最终代表性固件。具体 Commit 和产物哈希见[构建验证](BUILD_VALIDATION.zh.md)。

--- a/docs/build-logs/Ai-Thinker-WB2-helloworld-clean-build-1.log
+++ b/docs/build-logs/Ai-Thinker-WB2-helloworld-clean-build-1.log
@@ -1,0 +1,431 @@
+Your configuration chipname is Ai-Thinker Ai-WB2 Wi-Fi&BLE Module
+Your configuration chipname is Ai-Thinker Ai-WB2 Wi-Fi&BLE Module
+RM libromfs.a src/bl_romfs.o src/bl_romfs.d component_project_vars.mk
+RM libvfs.a src/vfs.o src/vfs_file.o src/vfs_inode.o src/vfs_register.o device/vfs_uart.o device/vfs_adc.o device/vfs_spi.o device/vfs_gpio.o device/vfs_pwm.o src/vfs.d src/vfs_file.d src/vfs_inode.d src/vfs_register.d device/vfs_uart.d device/vfs_adc.d device/vfs_spi.d device/vfs_gpio.d device/vfs_pwm.d component_project_vars.mk
+RM libnewlibc.a ./syscalls.o ./assert.o ./syscalls.d ./assert.d component_project_vars.mk
+RM liblwip.a lwip-port/FreeRTOS/ethernetif.o lwip-port/FreeRTOS/sys_arch.o src/api/api_lib.o src/api/api_msg.o src/api/err.o src/api/if_api.o src/api/netbuf.o src/api/netdb.o src/api/netifapi.o src/api/sockets.o src/api/tcpip.o src/apps/altcp_tls/altcp_tls_mbedtls.o src/apps/altcp_tls/altcp_tls_mbedtls_mem.o src/core/altcp.o src/core/altcp_alloc.o src/core/altcp_tcp.o src/core/def.o src/core/dns.o src/core/inet_chksum.o src/core/init.o src/core/ip.o src/core/ipv4/autoip.o src/core/ipv4/dhcp.o src/core/ipv4/etharp.o src/core/ipv4/icmp.o src/core/ipv4/igmp.o src/core/ipv4/ip4.o src/core/ipv4/ip4_addr.o src/core/ipv4/ip4_frag.o src/core/mem.o src/core/memp.o src/core/netif.o src/core/pbuf.o src/core/raw.o src/core/stats.o src/core/sys.o src/core/tcp.o src/core/tcp_in.o src/core/tcp_out.o src/core/timeouts.o src/core/udp.o src/core/utils.o src/netif/bridgeif.o src/netif/bridgeif_fdb.o src/netif/ethernet.o src/netif/lowpan6.o src/netif/lowpan6_ble.o src/netif/lowpan6_common.o src/netif/slipif.o src/netif/zepif.o lwip-port/FreeRTOS/ethernetif.d lwip-port/FreeRTOS/sys_arch.d src/api/api_lib.d src/api/api_msg.d src/api/err.d src/api/if_api.d src/api/netbuf.d src/api/netdb.d src/api/netifapi.d src/api/sockets.d src/api/tcpip.d src/apps/altcp_tls/altcp_tls_mbedtls.d src/apps/altcp_tls/altcp_tls_mbedtls_mem.d src/core/altcp.d src/core/altcp_alloc.d src/core/altcp_tcp.d src/core/def.d src/core/dns.d src/core/inet_chksum.d src/core/init.d src/core/ip.d src/core/ipv4/autoip.d src/core/ipv4/dhcp.d src/core/ipv4/etharp.d src/core/ipv4/icmp.d src/core/ipv4/igmp.d src/core/ipv4/ip4.d src/core/ipv4/ip4_addr.d src/core/ipv4/ip4_frag.d src/core/mem.d src/core/memp.d src/core/netif.d src/core/pbuf.d src/core/raw.d src/core/stats.d src/core/sys.d src/core/tcp.d src/core/tcp_in.d src/core/tcp_out.d src/core/timeouts.d src/core/udp.d src/core/utils.d src/netif/bridgeif.d src/netif/bridgeif_fdb.d src/netif/ethernet.d src/netif/lowpan6.d src/netif/lowpan6_ble.d src/netif/lowpan6_common.d src/netif/slipif.d src/netif/zepif.d component_project_vars.mk
+RM libhosal.a adapter/hosal_adpt_iotsdk.o bl602_hal/bl_uart.o bl602_hal/bl_chip.o bl602_hal/bl_cks.o bl602_hal/bl_sys.o bl602_hal/bl_sys_cli.o bl602_hal/bl_dma.o bl602_hal/bl_irq.o bl602_hal/bl_sec.o bl602_hal/bl_ir.o bl602_hal/bl_boot2.o bl602_hal/bl_timer.o bl602_hal/bl_hbn.o bl602_hal/bl_efuse.o bl602_hal/bl_flash.o bl602_hal/bl_gpio.o bl602_hal/bl_gpio_cli.o bl602_hal/hal_gpio.o bl602_hal/hal_button.o bl602_hal/bl_pwm.o bl602_hal/bl_sec_aes.o bl602_hal/bl_wifi.o bl602_hal/bl_wdt.o bl602_hal/bl_wdt_cli.o bl602_hal/bl_clocktree.o bl602_hal/hal_boot2.o bl602_hal/hal_sys.o bl602_hal/hal_board.o bl602_hal/hal_ir.o bl602_hal/bl_adc.o bl602_hal/bl_dac_audio.o bl602_hal/bl_i2c.o bl602_hal/bl_pm.o bl602_hal/bl_pds.o bl602_hal/hosal_pwm.o bl602_hal/hal_pds.o bl602_hal/hosal_rng.o bl602_hal/bl_rtc.o bl602_hal/hal_hbn.o bl602_hal/hal_hbnram.o bl602_hal/hosal_rtc.o bl602_hal/hosal_gpio.o bl602_hal/hosal_adc.o bl602_hal/hosal_spi.o bl602_hal/hal_hwtimer.o bl602_hal/hal_wifi.o bl602_hal/hosal_wdg.o platform_hal/platform_hal_device.o bl602_hal/hosal_uart.o bl602_hal/hosal_dma.o bl602_hal/hosal_flash.o bl602_hal/hosal_dac.o bl602_hal/hosal_i2c.o bl602_hal/hosal_ota.o bl602_hal/hosal_timer.o bl602_hal/hosal_efuse.o sec_common/bl_sec_sha.o sec_common/bl_sec_pka.o sec_common/bl_sec_aes.o sec_common/bl_sec_gmac.o adapter/hosal_adpt_iotsdk.d bl602_hal/bl_uart.d bl602_hal/bl_chip.d bl602_hal/bl_cks.d bl602_hal/bl_sys.d bl602_hal/bl_sys_cli.d bl602_hal/bl_dma.d bl602_hal/bl_irq.d bl602_hal/bl_sec.d bl602_hal/bl_ir.d bl602_hal/bl_boot2.d bl602_hal/bl_timer.d bl602_hal/bl_hbn.d bl602_hal/bl_efuse.d bl602_hal/bl_flash.d bl602_hal/bl_gpio.d bl602_hal/bl_gpio_cli.d bl602_hal/hal_gpio.d bl602_hal/hal_button.d bl602_hal/bl_pwm.d bl602_hal/bl_sec_aes.d bl602_hal/bl_wifi.d bl602_hal/bl_wdt.d bl602_hal/bl_wdt_cli.d bl602_hal/bl_clocktree.d bl602_hal/hal_boot2.d bl602_hal/hal_sys.d bl602_hal/hal_board.d bl602_hal/hal_ir.d bl602_hal/bl_adc.d bl602_hal/bl_dac_audio.d bl602_hal/bl_i2c.d bl602_hal/bl_pm.d bl602_hal/bl_pds.d bl602_hal/hosal_pwm.d bl602_hal/hal_pds.d bl602_hal/hosal_rng.d bl602_hal/bl_rtc.d bl602_hal/hal_hbn.d bl602_hal/hal_hbnram.d bl602_hal/hosal_rtc.d bl602_hal/hosal_gpio.d bl602_hal/hosal_adc.d bl602_hal/hosal_spi.d bl602_hal/hal_hwtimer.d bl602_hal/hal_wifi.d bl602_hal/hosal_wdg.d platform_hal/platform_hal_device.d bl602_hal/hosal_uart.d bl602_hal/hosal_dma.d bl602_hal/hosal_flash.d bl602_hal/hosal_dac.d bl602_hal/hosal_i2c.d bl602_hal/hosal_ota.d bl602_hal/hosal_timer.d bl602_hal/hosal_efuse.d sec_common/bl_sec_sha.d sec_common/bl_sec_pka.d sec_common/bl_sec_aes.d sec_common/bl_sec_gmac.d component_project_vars.mk
+RM libbl602.a evb/src/boot/gcc/entry.o evb/src/boot/gcc/start.o evb/src/debug.o evb/src/strntoumax.o bfl_main.o evb/src/boot/gcc/entry.d evb/src/boot/gcc/start.d evb/src/debug.d evb/src/strntoumax.d bfl_main.d component_project_vars.mk
+RM libbl602_std.a bl602_std/StdDriver/Src/bl602_uart.o bl602_std/StdDriver/Src/bl602_adc.o bl602_std/StdDriver/Src/bl602_sec_eng.o bl602_std/StdDriver/Src/bl602_dma.o bl602_std/StdDriver/Src/bl602_common.o bl602_std/StdDriver/Src/bl602_glb.o bl602_std/StdDriver/Src/bl602_hbn.o bl602_std/StdDriver/Src/bl602_timer.o bl602_std/StdDriver/Src/bl602_aon.o bl602_std/StdDriver/Src/bl602_pds.o bl602_std/StdDriver/Src/bl602_pwm.o bl602_std/StdDriver/Src/bl602_l1c.o bl602_std/StdDriver/Src/bl602_ef_ctrl.o bl602_std/StdDriver/Src/bl602_mfg_efuse.o bl602_std/StdDriver/Src/bl602_mfg_flash.o bl602_std/StdDriver/Src/bl602_mfg_media.o bl602_std/StdDriver/Src/bl602_dac.o bl602_std/StdDriver/Src/bl602_ir.o bl602_std/StdDriver/Src/bl602_spi.o bl602_std/StdDriver/Src/bl602_i2c.o bl602_std/StdDriver/Src/bl602_sdu.o bl602_std/Common/soft_crc/softcrc.o bl602_std/Common/xz/xz_crc32.o bl602_std/Common/xz/xz_dec_lzma2.o bl602_std/Common/xz/xz_dec_stream.o bl602_std/Common/xz/xz_decompress.o bl602_std/Common/xz/xz_port.o bl602_std/Common/cipher_suite/src/bflb_crypt.o bl602_std/Common/cipher_suite/src/bflb_hash.o bl602_std/Common/cipher_suite/src/bflb_dsa.o bl602_std/Common/cipher_suite/src/bflb_ecdsa.o bl602_std/Common/platform_print/platform_device.o bl602_std/Common/platform_print/platform_gpio.o bl602_std/Common/ring_buffer/ring_buffer.o bl602_std/RISCV/Device/Bouffalo/BL602/Startup/interrupt.o bl602_std/StdDriver/Src/bl602_romapi.o bl602_std/StdDriver/Src/bl602_sflash_ext.o bl602_std/StdDriver/Src/bl602_sf_cfg_ext.o bl602_std/StdDriver/Src/bl602_xip_sflash_ext.o bl602_std/StdDriver/Src/bl602_uart.d bl602_std/StdDriver/Src/bl602_adc.d bl602_std/StdDriver/Src/bl602_sec_eng.d bl602_std/StdDriver/Src/bl602_dma.d bl602_std/StdDriver/Src/bl602_common.d bl602_std/StdDriver/Src/bl602_glb.d bl602_std/StdDriver/Src/bl602_hbn.d bl602_std/StdDriver/Src/bl602_timer.d bl602_std/StdDriver/Src/bl602_aon.d bl602_std/StdDriver/Src/bl602_pds.d bl602_std/StdDriver/Src/bl602_pwm.d bl602_std/StdDriver/Src/bl602_l1c.d bl602_std/StdDriver/Src/bl602_ef_ctrl.d bl602_std/StdDriver/Src/bl602_mfg_efuse.d bl602_std/StdDriver/Src/bl602_mfg_flash.d bl602_std/StdDriver/Src/bl602_mfg_media.d bl602_std/StdDriver/Src/bl602_dac.d bl602_std/StdDriver/Src/bl602_ir.d bl602_std/StdDriver/Src/bl602_spi.d bl602_std/StdDriver/Src/bl602_i2c.d bl602_std/StdDriver/Src/bl602_sdu.d bl602_std/Common/soft_crc/softcrc.d bl602_std/Common/xz/xz_crc32.d bl602_std/Common/xz/xz_dec_lzma2.d bl602_std/Common/xz/xz_dec_stream.d bl602_std/Common/xz/xz_decompress.d bl602_std/Common/xz/xz_port.d bl602_std/Common/cipher_suite/src/bflb_crypt.d bl602_std/Common/cipher_suite/src/bflb_hash.d bl602_std/Common/cipher_suite/src/bflb_dsa.d bl602_std/Common/cipher_suite/src/bflb_ecdsa.d bl602_std/Common/platform_print/platform_device.d bl602_std/Common/platform_print/platform_gpio.d bl602_std/Common/ring_buffer/ring_buffer.d bl602_std/RISCV/Device/Bouffalo/BL602/Startup/interrupt.d bl602_std/StdDriver/Src/bl602_romapi.d bl602_std/StdDriver/Src/bl602_sflash_ext.d bl602_std/StdDriver/Src/bl602_sf_cfg_ext.d bl602_std/StdDriver/Src/bl602_xip_sflash_ext.d component_project_vars.mk
+RM libfreertos_riscv_ram.a event_groups.o list.o queue.o stream_buffer.o tasks.o timers.o misaligned/misaligned_ldst.o misaligned/fp_asm.o panic/panic_c.o portable/GCC/RISC-V/port.o portable/GCC/RISC-V/portASM.o portable/MemMang/heap_5.o event_groups.d list.d queue.d stream_buffer.d tasks.d timers.d misaligned/misaligned_ldst.d misaligned/fp_asm.d panic/panic_c.d portable/GCC/RISC-V/port.d portable/GCC/RISC-V/portASM.d portable/MemMang/heap_5.d component_project_vars.mk
+RM libmbedtls_lts.a mbedtls/library/xtea.o mbedtls/library/aes.o mbedtls/library/aesni.o mbedtls/library/arc4.o mbedtls/library/aria.o mbedtls/library/asn1parse.o mbedtls/library/asn1write.o mbedtls/library/base64.o mbedtls/library/blowfish.o mbedtls/library/camellia.o mbedtls/library/ccm.o mbedtls/library/certs.o mbedtls/library/chacha20.o mbedtls/library/chachapoly.o mbedtls/library/cipher.o mbedtls/library/cipher_wrap.o mbedtls/library/cmac.o mbedtls/library/constant_time.o mbedtls/library/ctr_drbg.o mbedtls/library/debug.o mbedtls/library/des.o mbedtls/library/dhm.o mbedtls/library/ecdh.o mbedtls/library/ecdsa.o mbedtls/library/ecjpake.o mbedtls/library/ecp.o mbedtls/library/ecp_curves.o mbedtls/library/entropy.o mbedtls/library/entropy_poll.o mbedtls/library/error.o mbedtls/library/gcm.o mbedtls/library/havege.o mbedtls/library/hkdf.o mbedtls/library/hmac_drbg.o mbedtls/library/md2.o mbedtls/library/md4.o mbedtls/library/md5.o mbedtls/library/md.o mbedtls/library/memory_buffer_alloc.o mbedtls/library/mps_reader.o mbedtls/library/mps_trace.o mbedtls/library/nist_kw.o mbedtls/library/oid.o mbedtls/library/padlock.o mbedtls/library/pem.o mbedtls/library/pk.o mbedtls/library/pkcs11.o mbedtls/library/pkcs12.o mbedtls/library/pkcs5.o mbedtls/library/pk_wrap.o mbedtls/library/pkwrite.o mbedtls/library/platform.o mbedtls/library/platform_util.o mbedtls/library/poly1305.o mbedtls/library/ripemd160.o mbedtls/library/rsa.o mbedtls/library/rsa_internal.o mbedtls/library/sha1.o mbedtls/library/sha256.o mbedtls/library/sha512.o mbedtls/library/ssl_cache.o mbedtls/library/ssl_ciphersuites.o mbedtls/library/ssl_cli.o mbedtls/library/ssl_cookie.o mbedtls/library/ssl_msg.o mbedtls/library/ssl_srv.o mbedtls/library/ssl_ticket.o mbedtls/library/ssl_tls13_keys.o mbedtls/library/ssl_tls.o mbedtls/library/threading.o mbedtls/library/timing.o mbedtls/library/version.o mbedtls/library/version_features.o mbedtls/library/x509.o mbedtls/library/x509_create.o mbedtls/library/x509_crl.o mbedtls/library/x509_crt.o mbedtls/library/x509_csr.o mbedtls/library/x509write_crt.o mbedtls/library/x509write_csr.o port/pkparse.o port/mbedtls_port_mem.o port/net_sockets.o port/hw_entropy_poll.o port/bignum_ext.o mbedtls/library/bignum.o port/test_case.o mbedtls/library/xtea.d mbedtls/library/aes.d mbedtls/library/aesni.d mbedtls/library/arc4.d mbedtls/library/aria.d mbedtls/library/asn1parse.d mbedtls/library/asn1write.d mbedtls/library/base64.d mbedtls/library/blowfish.d mbedtls/library/camellia.d mbedtls/library/ccm.d mbedtls/library/certs.d mbedtls/library/chacha20.d mbedtls/library/chachapoly.d mbedtls/library/cipher.d mbedtls/library/cipher_wrap.d mbedtls/library/cmac.d mbedtls/library/constant_time.d mbedtls/library/ctr_drbg.d mbedtls/library/debug.d mbedtls/library/des.d mbedtls/library/dhm.d mbedtls/library/ecdh.d mbedtls/library/ecdsa.d mbedtls/library/ecjpake.d mbedtls/library/ecp.d mbedtls/library/ecp_curves.d mbedtls/library/entropy.d mbedtls/library/entropy_poll.d mbedtls/library/error.d mbedtls/library/gcm.d mbedtls/library/havege.d mbedtls/library/hkdf.d mbedtls/library/hmac_drbg.d mbedtls/library/md2.d mbedtls/library/md4.d mbedtls/library/md5.d mbedtls/library/md.d mbedtls/library/memory_buffer_alloc.d mbedtls/library/mps_reader.d mbedtls/library/mps_trace.d mbedtls/library/nist_kw.d mbedtls/library/oid.d mbedtls/library/padlock.d mbedtls/library/pem.d mbedtls/library/pk.d mbedtls/library/pkcs11.d mbedtls/library/pkcs12.d mbedtls/library/pkcs5.d mbedtls/library/pk_wrap.d mbedtls/library/pkwrite.d mbedtls/library/platform.d mbedtls/library/platform_util.d mbedtls/library/poly1305.d mbedtls/library/ripemd160.d mbedtls/library/rsa.d mbedtls/library/rsa_internal.d mbedtls/library/sha1.d mbedtls/library/sha256.d mbedtls/library/sha512.d mbedtls/library/ssl_cache.d mbedtls/library/ssl_ciphersuites.d mbedtls/library/ssl_cli.d mbedtls/library/ssl_cookie.d mbedtls/library/ssl_msg.d mbedtls/library/ssl_srv.d mbedtls/library/ssl_ticket.d mbedtls/library/ssl_tls13_keys.d mbedtls/library/ssl_tls.d mbedtls/library/threading.d mbedtls/library/timing.d mbedtls/library/version.d mbedtls/library/version_features.d mbedtls/library/x509.d mbedtls/library/x509_create.d mbedtls/library/x509_crl.d mbedtls/library/x509_crt.d mbedtls/library/x509_csr.d mbedtls/library/x509write_crt.d mbedtls/library/x509write_csr.d port/pkparse.d port/mbedtls_port_mem.d port/net_sockets.d port/hw_entropy_poll.d port/bignum_ext.d mbedtls/library/bignum.d port/test_case.d component_project_vars.mk
+RM libblfdt.a src/fdt.o src/fdt_ro.o src/fdt_wip.o src/fdt_sw.o src/fdt_rw.o src/fdt_strerror.o src/fdt_empty_tree.o src/fdt_addresses.o src/fdt_overlay.o test/tc_blfdt_dump.o test/tc_blfdt_wifi.o test/blfdt_cli_test.o src/fdt.d src/fdt_ro.d src/fdt_wip.d src/fdt_sw.d src/fdt_rw.d src/fdt_strerror.d src/fdt_empty_tree.d src/fdt_addresses.d src/fdt_overlay.d test/tc_blfdt_dump.d test/tc_blfdt_wifi.d test/blfdt_cli_test.d component_project_vars.mk
+RM libblog.a ./blog.o ./blog.d component_project_vars.mk
+RM libblog_testc.a blog_testc.o blog_testc1_diable.o blog_testc2_full.o blog_testc3_nopri.o blog_testc4_onlypri.o blog_testc.d blog_testc1_diable.d blog_testc2_full.d blog_testc3_nopri.d blog_testc4_onlypri.d component_project_vars.mk
+RM libcli.a cli/cli.o cli/cli.d component_project_vars.mk
+RM libcoredump.a bl_coredump.o bl_coredump.d component_project_vars.mk
+RM libyloop.a src/yloop.o src/select.o src/aos_freertos.o src/device.o src/local_event.o src/yloop.d src/select.d src/aos_freertos.d src/device.d src/local_event.d component_project_vars.mk
+RM libblmtd.a bl_mtd.o bl_mtd.d component_project_vars.mk
+RM libbloop.a src/bloop_base.o src/bloop_handler_sys.o src/bloop_base.d src/bloop_handler_sys.d component_project_vars.mk
+RM liblooprt.a src/looprt.o src/looprt_test_cli.o src/looprt.d src/looprt_test_cli.d component_project_vars.mk
+RM libloopset.a src/loopset_led.o src/loopset_led_cli.o src/loopset_ir.o src/loopset_pwm.o src/loopset_led.d src/loopset_led_cli.d src/loopset_ir.d src/loopset_pwm.d component_project_vars.mk
+RM libbltime.a bl_sys_time.o bl_sys_time_cli.o bl_sys_time.d bl_sys_time_cli.d component_project_vars.mk
+RM libutils.a src/utils_hex.o src/utils_crc.o src/utils_sha256.o src/utils_fec.o src/utils_log.o src/utils_dns.o src/utils_list.o src/utils_ringblk.o src/utils_rbtree.o src/utils_hexdump.o src/utils_time.o src/utils_notifier.o src/utils_getopt.o src/utils_string.o src/utils_hmac_sha1_fast.o src/utils_psk_fast.o src/utils_memp.o src/utils_tlv_bl.o src/utils_base64.o src/utils_bitmap_window.o src/test/test_utils_base64.o src/test/test_utils_ringblk.o src/test/test_utils_bitmap_window.o src/utils_hex.d src/utils_crc.d src/utils_sha256.d src/utils_fec.d src/utils_log.d src/utils_dns.d src/utils_list.d src/utils_ringblk.d src/utils_rbtree.d src/utils_hexdump.d src/utils_time.d src/utils_notifier.d src/utils_getopt.d src/utils_string.d src/utils_hmac_sha1_fast.d src/utils_psk_fast.d src/utils_memp.d src/utils_tlv_bl.d src/utils_base64.d src/utils_bitmap_window.d src/test/test_utils_base64.d src/test/test_utils_ringblk.d src/test/test_utils_bitmap_window.d component_project_vars.mk
+RM libhelloworld.a ./main.o ./main.d component_project_vars.mk
+RM /home/fae/codex-builds/Ai-Thinker-WB2-2420da7/applications/get-started/helloworld/build_out/helloworld.elf
+Your configuration chipname is Ai-Thinker Ai-WB2 Wi-Fi&BLE Module
+Your configuration chipname is Ai-Thinker Ai-WB2 Wi-Fi&BLE Module
+AS build_out/bl602/evb/src/boot/gcc/entry.o
+AS build_out/bl602/evb/src/boot/gcc/start.o
+CC build_out/blmtd/bl_mtd.o
+CC build_out/blog/blog.o
+CC build_out/blfdt/src/fdt.o
+CC build_out/blfdt/src/fdt_ro.o
+CC build_out/blog_testc/blog_testc.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_uart.o
+CC build_out/bl602/evb/src/debug.o
+CC build_out/bl602/evb/src/strntoumax.o
+CC build_out/blog_testc/blog_testc1_diable.o
+CC build_out/bl602/bfl_main.o
+CC build_out/blog_testc/blog_testc2_full.o
+AR build_out/blmtd/libblmtd.a
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/stage/blog_testc/blog_testc2_full.c: In function 'test_buf':
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/stage/blog_testc/blog_testc2_full.c:18:364: warning: conversion from 'unsigned int' to 'uint8_t' {aka 'unsigned char'} changes value from '256' to '0' [-Woverflow]
+   18 |     blog_debug_hexdump("hexdumpbuf", buf, sizeof(buf));
+      |                                                                                                                                                                                                                                                                                                                                                                            ^          
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/stage/blog_testc/blog_testc2_full.c:19:368: warning: conversion from 'unsigned int' to 'uint8_t' {aka 'unsigned char'} changes value from '256' to '0' [-Woverflow]
+   19 |     blog_info_hexdump("hexdumpbuf", buf, sizeof(buf));
+      |                                                                                                                                                                                                                                                                                                                                                                                ^          
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/stage/blog_testc/blog_testc2_full.c:20:368: warning: conversion from 'unsigned int' to 'uint8_t' {aka 'unsigned char'} changes value from '256' to '0' [-Woverflow]
+   20 |     blog_warn_hexdump("hexdumpbuf", buf, sizeof(buf));
+      |                                                                                                                                                                                                                                                                                                                                                                                ^          
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/stage/blog_testc/blog_testc2_full.c:21:371: warning: conversion from 'unsigned int' to 'uint8_t' {aka 'unsigned char'} changes value from '256' to '0' [-Woverflow]
+   21 |     blog_error_hexdump("hexdumpbuf", buf, sizeof(buf));
+      |                                                                                                                                                                                                                                                                                                                                                                                   ^          
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/stage/blog_testc/blog_testc2_full.c:22:372: warning: conversion from 'unsigned int' to 'uint8_t' {aka 'unsigned char'} changes value from '256' to '0' [-Woverflow]
+   22 |     blog_assert_hexdump("hexdumpbuf", buf, sizeof(buf));
+      |                                                                                                                                                                                                                                                                                                                                                                                    ^          
+CC build_out/bloop/src/bloop_base.o
+CC build_out/blfdt/src/fdt_wip.o
+AR build_out/blog/libblog.a
+CC build_out/blfdt/src/fdt_sw.o
+CC build_out/blfdt/src/fdt_rw.o
+CC build_out/blfdt/src/fdt_strerror.o
+CC build_out/blog_testc/blog_testc3_nopri.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_adc.o
+CC build_out/blfdt/src/fdt_empty_tree.o
+CC build_out/blog_testc/blog_testc4_onlypri.o
+CC build_out/blfdt/src/fdt_addresses.o
+CC build_out/bloop/src/bloop_handler_sys.o
+CC build_out/blfdt/src/fdt_overlay.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_sec_eng.o
+CC build_out/blfdt/test/tc_blfdt_dump.o
+AR build_out/bl602/libbl602.a
+CC build_out/blfdt/test/tc_blfdt_wifi.o
+AR build_out/blog_testc/libblog_testc.a
+AR build_out/bloop/libbloop.a
+CC build_out/blfdt/test/blfdt_cli_test.o
+CC build_out/bltime/bl_sys_time.o
+CC build_out/bltime/bl_sys_time_cli.o
+CC build_out/cli/cli/cli.o
+CC build_out/coredump/bl_coredump.o
+AR build_out/bltime/libbltime.a
+CC build_out/helloworld/main.o
+CC build_out/freertos_riscv_ram/event_groups.o
+CC build_out/freertos_riscv_ram/list.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_dma.o
+AR build_out/blfdt/libblfdt.a
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_common.o
+AR build_out/helloworld/libhelloworld.a
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_glb.o
+CC build_out/freertos_riscv_ram/queue.o
+AR build_out/coredump/libcoredump.a
+CC build_out/hosal/adapter/hosal_adpt_iotsdk.o
+CC build_out/freertos_riscv_ram/stream_buffer.o
+CC build_out/hosal/bl602_hal/bl_uart.o
+CC build_out/hosal/bl602_hal/bl_chip.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_hbn.o
+CC build_out/hosal/bl602_hal/bl_cks.o
+CC build_out/hosal/bl602_hal/bl_sys.o
+CC build_out/freertos_riscv_ram/tasks.o
+CC build_out/freertos_riscv_ram/timers.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_timer.o
+CC build_out/hosal/bl602_hal/bl_sys_cli.o
+CC build_out/freertos_riscv_ram/misaligned/misaligned_ldst.o
+AS build_out/freertos_riscv_ram/misaligned/fp_asm.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_aon.o
+AR build_out/cli/libcli.a
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_pds.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_pwm.o
+CC build_out/hosal/bl602_hal/bl_dma.o
+CC build_out/hosal/bl602_hal/bl_irq.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_l1c.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_ef_ctrl.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_mfg_efuse.o
+CC build_out/freertos_riscv_ram/panic/panic_c.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_mfg_flash.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_mfg_media.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_dac.o
+CC build_out/hosal/bl602_hal/bl_sec.o
+CC build_out/hosal/bl602_hal/bl_ir.o
+CC build_out/hosal/bl602_hal/bl_boot2.o
+CC build_out/hosal/bl602_hal/bl_timer.o
+CC build_out/hosal/bl602_hal/bl_hbn.o
+CC build_out/hosal/bl602_hal/bl_efuse.o
+CC build_out/hosal/bl602_hal/bl_flash.o
+CC build_out/hosal/bl602_hal/bl_gpio.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_ir.o
+CC build_out/hosal/bl602_hal/bl_gpio_cli.o
+CC build_out/looprt/src/looprt.o
+CC build_out/hosal/bl602_hal/hal_gpio.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_spi.o
+CC build_out/hosal/bl602_hal/hal_button.o
+CC build_out/looprt/src/looprt_test_cli.o
+AR build_out/looprt/liblooprt.a
+CC build_out/loopset/src/loopset_led.o
+CC build_out/loopset/src/loopset_led_cli.o
+CC build_out/loopset/src/loopset_ir.o
+CC build_out/loopset/src/loopset_pwm.o
+CC build_out/hosal/bl602_hal/bl_pwm.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_i2c.o
+CC build_out/freertos_riscv_ram/portable/GCC/RISC-V/port.o
+AS build_out/freertos_riscv_ram/portable/GCC/RISC-V/portASM.o
+CC build_out/lwip/lwip-port/FreeRTOS/ethernetif.o
+AR build_out/loopset/libloopset.a
+CC build_out/freertos_riscv_ram/portable/MemMang/heap_5.o
+CC build_out/mbedtls_lts/mbedtls/library/xtea.o
+CC build_out/hosal/bl602_hal/bl_sec_aes.o
+CC build_out/mbedtls_lts/mbedtls/library/aes.o
+CC build_out/lwip/lwip-port/FreeRTOS/sys_arch.o
+CC build_out/hosal/bl602_hal/bl_wifi.o
+CC build_out/lwip/src/api/api_lib.o
+AR build_out/freertos_riscv_ram/libfreertos_riscv_ram.a
+CC build_out/lwip/src/api/api_msg.o
+CC build_out/lwip/src/api/err.o
+CC build_out/newlibc/syscalls.o
+CC build_out/lwip/src/api/if_api.o
+CC build_out/newlibc/assert.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_sdu.o
+CC build_out/bl602_std/bl602_std/Common/soft_crc/softcrc.o
+CC build_out/bl602_std/bl602_std/Common/xz/xz_crc32.o
+CC build_out/hosal/bl602_hal/bl_wdt.o
+AR build_out/newlibc/libnewlibc.a
+CC build_out/hosal/bl602_hal/bl_wdt_cli.o
+CC build_out/bl602_std/bl602_std/Common/xz/xz_dec_lzma2.o
+CC build_out/hosal/bl602_hal/bl_clocktree.o
+CC build_out/bl602_std/bl602_std/Common/xz/xz_dec_stream.o
+CC build_out/hosal/bl602_hal/hal_boot2.o
+CC build_out/hosal/bl602_hal/hal_sys.o
+CC build_out/mbedtls_lts/mbedtls/library/aesni.o
+CC build_out/mbedtls_lts/mbedtls/library/arc4.o
+CC build_out/mbedtls_lts/mbedtls/library/aria.o
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/platform/hosal/bl602_hal/hal_sys.c: In function 'hal_sys_romapi_get':
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/platform/hosal/bl602_hal/hal_sys.c:40:65: warning: array subscript 88 is outside array bounds of 'uint8_t[1]' {aka 'unsigned char[1]'} [-Warray-bounds]
+   40 |     *(gp_data_start + 0) = (uint32_t)((uint8_t*)(gp_data_start) + 0x58);
+      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/platform/hosal/bl602_hal/hal_sys.c:29:20: note: while referencing '__global_pointer_head$'
+   29 |     extern uint8_t __global_pointer_head$;
+      |                    ^~~~~~~~~~~~~~~~~~~~~~
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/platform/hosal/bl602_hal/hal_sys.c:42:65: warning: array subscript 96 is outside array bounds of 'uint8_t[1]' {aka 'unsigned char[1]'} [-Warray-bounds]
+   42 |     *(gp_data_start + 1) = (uint32_t)((uint8_t*)(gp_data_start) + 0x60);
+      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/platform/hosal/bl602_hal/hal_sys.c:29:20: note: while referencing '__global_pointer_head$'
+   29 |     extern uint8_t __global_pointer_head$;
+      |                    ^~~~~~~~~~~~~~~~~~~~~~
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/platform/hosal/bl602_hal/hal_sys.c:42:5: warning: array subscript 1 is outside array bounds of 'uint8_t[1]' {aka 'unsigned char[1]'} [-Warray-bounds]
+   42 |     *(gp_data_start + 1) = (uint32_t)((uint8_t*)(gp_data_start) + 0x60);
+      |     ^~~~~~~~~~~~~~~~~~~~
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/platform/hosal/bl602_hal/hal_sys.c:29:20: note: while referencing '__global_pointer_head$'
+   29 |     extern uint8_t __global_pointer_head$;
+      |                    ^~~~~~~~~~~~~~~~~~~~~~
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/platform/hosal/bl602_hal/hal_sys.c:44:5: warning: array subscript 2 is outside array bounds of 'uint8_t[1]' {aka 'unsigned char[1]'} [-Warray-bounds]
+   44 |     *(gp_data_start + 2) = 32 * 1000 / 1000;//Use 32K
+      |     ^~~~~~~~~~~~~~~~~~~~
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/platform/hosal/bl602_hal/hal_sys.c:29:20: note: while referencing '__global_pointer_head$'
+   29 |     extern uint8_t __global_pointer_head$;
+      |                    ^~~~~~~~~~~~~~~~~~~~~~
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/platform/hosal/bl602_hal/hal_sys.c:37:21: warning: array subscript 1116 is outside array bounds of 'uint8_t[1]' {aka 'unsigned char[1]'} [-Warray-bounds]
+   37 |     romapi_freertos = (struct romapi_freertos_map*) (((uint8_t*)gp_data_start) + 0x45c);
+      |     ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/platform/hosal/bl602_hal/hal_sys.c:29:20: note: while referencing '__global_pointer_head$'
+   29 |     extern uint8_t __global_pointer_head$;
+      |                    ^~~~~~~~~~~~~~~~~~~~~~
+CC build_out/mbedtls_lts/mbedtls/library/asn1parse.o
+CC build_out/mbedtls_lts/mbedtls/library/asn1write.o
+CC build_out/hosal/bl602_hal/hal_board.o
+CC build_out/hosal/bl602_hal/hal_ir.o
+CC build_out/bl602_std/bl602_std/Common/xz/xz_decompress.o
+CC build_out/bl602_std/bl602_std/Common/xz/xz_port.o
+CC build_out/hosal/bl602_hal/bl_adc.o
+CC build_out/bl602_std/bl602_std/Common/cipher_suite/src/bflb_crypt.o
+CC build_out/hosal/bl602_hal/bl_dac_audio.o
+CC build_out/hosal/bl602_hal/bl_i2c.o
+CC build_out/mbedtls_lts/mbedtls/library/base64.o
+CC build_out/mbedtls_lts/mbedtls/library/blowfish.o
+CC build_out/lwip/src/api/netbuf.o
+CC build_out/lwip/src/api/netdb.o
+CC build_out/lwip/src/api/netifapi.o
+CC build_out/lwip/src/api/sockets.o
+CC build_out/lwip/src/api/tcpip.o
+CC build_out/mbedtls_lts/mbedtls/library/camellia.o
+CC build_out/bl602_std/bl602_std/Common/cipher_suite/src/bflb_hash.o
+CC build_out/mbedtls_lts/mbedtls/library/ccm.o
+CC build_out/bl602_std/bl602_std/Common/cipher_suite/src/bflb_dsa.o
+CC build_out/mbedtls_lts/mbedtls/library/certs.o
+CC build_out/mbedtls_lts/mbedtls/library/chacha20.o
+CC build_out/mbedtls_lts/mbedtls/library/chachapoly.o
+CC build_out/hosal/bl602_hal/bl_pm.o
+CC build_out/mbedtls_lts/mbedtls/library/cipher.o
+CC build_out/hosal/bl602_hal/bl_pds.o
+CC build_out/mbedtls_lts/mbedtls/library/cipher_wrap.o
+CC build_out/mbedtls_lts/mbedtls/library/cmac.o
+CC build_out/lwip/src/apps/altcp_tls/altcp_tls_mbedtls.o
+CC build_out/lwip/src/apps/altcp_tls/altcp_tls_mbedtls_mem.o
+CC build_out/bl602_std/bl602_std/Common/cipher_suite/src/bflb_ecdsa.o
+CC build_out/mbedtls_lts/mbedtls/library/constant_time.o
+CC build_out/mbedtls_lts/mbedtls/library/ctr_drbg.o
+CC build_out/lwip/src/core/altcp.o
+CC build_out/mbedtls_lts/mbedtls/library/debug.o
+CC build_out/hosal/bl602_hal/hosal_pwm.o
+CC build_out/mbedtls_lts/mbedtls/library/des.o
+CC build_out/mbedtls_lts/mbedtls/library/dhm.o
+CC build_out/mbedtls_lts/mbedtls/library/ecdh.o
+CC build_out/mbedtls_lts/mbedtls/library/ecdsa.o
+CC build_out/mbedtls_lts/mbedtls/library/ecjpake.o
+CC build_out/mbedtls_lts/mbedtls/library/ecp.o
+CC build_out/mbedtls_lts/mbedtls/library/ecp_curves.o
+CC build_out/bl602_std/bl602_std/Common/platform_print/platform_device.o
+CC build_out/hosal/bl602_hal/hal_pds.o
+CC build_out/hosal/bl602_hal/hosal_rng.o
+CC build_out/mbedtls_lts/mbedtls/library/entropy.o
+CC build_out/hosal/bl602_hal/bl_rtc.o
+CC build_out/hosal/bl602_hal/hal_hbn.o
+CC build_out/mbedtls_lts/mbedtls/library/entropy_poll.o
+CC build_out/mbedtls_lts/mbedtls/library/error.o
+CC build_out/bl602_std/bl602_std/Common/platform_print/platform_gpio.o
+CC build_out/bl602_std/bl602_std/Common/ring_buffer/ring_buffer.o
+CC build_out/bl602_std/bl602_std/RISCV/Device/Bouffalo/BL602/Startup/interrupt.o
+CC build_out/hosal/bl602_hal/hal_hbnram.o
+CC build_out/hosal/bl602_hal/hosal_rtc.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_romapi.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_sflash_ext.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_sf_cfg_ext.o
+CC build_out/mbedtls_lts/mbedtls/library/gcm.o
+CC build_out/mbedtls_lts/mbedtls/library/havege.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_xip_sflash_ext.o
+CC build_out/mbedtls_lts/mbedtls/library/hkdf.o
+CC build_out/romfs/src/bl_romfs.o
+CC build_out/mbedtls_lts/mbedtls/library/hmac_drbg.o
+CC build_out/mbedtls_lts/mbedtls/library/md2.o
+CC build_out/utils/src/utils_hex.o
+CC build_out/hosal/bl602_hal/hosal_gpio.o
+CC build_out/mbedtls_lts/mbedtls/library/md4.o
+CC build_out/utils/src/utils_crc.o
+CC build_out/utils/src/utils_sha256.o
+CC build_out/mbedtls_lts/mbedtls/library/md5.o
+CC build_out/lwip/src/core/altcp_alloc.o
+CC build_out/utils/src/utils_fec.o
+AR build_out/bl602_std/libbl602_std.a
+CC build_out/mbedtls_lts/mbedtls/library/md.o
+CC build_out/hosal/bl602_hal/hosal_adc.o
+CC build_out/vfs/src/vfs.o
+CC build_out/lwip/src/core/altcp_tcp.o
+CC build_out/utils/src/utils_log.o
+CC build_out/mbedtls_lts/mbedtls/library/memory_buffer_alloc.o
+CC build_out/utils/src/utils_dns.o
+CC build_out/lwip/src/core/def.o
+CC build_out/mbedtls_lts/mbedtls/library/mps_reader.o
+CC build_out/utils/src/utils_list.o
+CC build_out/mbedtls_lts/mbedtls/library/mps_trace.o
+AR build_out/romfs/libromfs.a
+CC build_out/mbedtls_lts/mbedtls/library/nist_kw.o
+CC build_out/yloop/src/yloop.o
+CC build_out/yloop/src/select.o
+CC build_out/vfs/src/vfs_file.o
+CC build_out/hosal/bl602_hal/hosal_spi.o
+CC build_out/mbedtls_lts/mbedtls/library/oid.o
+CC build_out/lwip/src/core/dns.o
+CC build_out/utils/src/utils_ringblk.o
+CC build_out/yloop/src/aos_freertos.o
+CC build_out/vfs/src/vfs_inode.o
+CC build_out/vfs/src/vfs_register.o
+CC build_out/utils/src/utils_rbtree.o
+CC build_out/mbedtls_lts/mbedtls/library/padlock.o
+CC build_out/vfs/device/vfs_uart.o
+CC build_out/vfs/device/vfs_adc.o
+CC build_out/mbedtls_lts/mbedtls/library/pem.o
+CC build_out/mbedtls_lts/mbedtls/library/pk.o
+CC build_out/yloop/src/device.o
+CC build_out/lwip/src/core/inet_chksum.o
+CC build_out/vfs/device/vfs_spi.o
+CC build_out/lwip/src/core/init.o
+CC build_out/mbedtls_lts/mbedtls/library/pkcs11.o
+CC build_out/yloop/src/local_event.o
+CC build_out/utils/src/utils_hexdump.o
+CC build_out/mbedtls_lts/mbedtls/library/pkcs12.o
+CC build_out/hosal/bl602_hal/hal_hwtimer.o
+CC build_out/mbedtls_lts/mbedtls/library/pkcs5.o
+CC build_out/mbedtls_lts/mbedtls/library/pk_wrap.o
+CC build_out/mbedtls_lts/mbedtls/library/pkwrite.o
+CC build_out/vfs/device/vfs_gpio.o
+CC build_out/lwip/src/core/ip.o
+CC build_out/mbedtls_lts/mbedtls/library/platform.o
+CC build_out/lwip/src/core/ipv4/autoip.o
+CC build_out/utils/src/utils_time.o
+CC build_out/lwip/src/core/ipv4/dhcp.o
+CC build_out/utils/src/utils_notifier.o
+AR build_out/yloop/libyloop.a
+CC build_out/mbedtls_lts/mbedtls/library/platform_util.o
+CC build_out/mbedtls_lts/mbedtls/library/poly1305.o
+CC build_out/vfs/device/vfs_pwm.o
+CC build_out/mbedtls_lts/mbedtls/library/ripemd160.o
+CC build_out/utils/src/utils_getopt.o
+CC build_out/mbedtls_lts/mbedtls/library/rsa.o
+CC build_out/hosal/bl602_hal/hal_wifi.o
+CC build_out/utils/src/utils_string.o
+CC build_out/mbedtls_lts/mbedtls/library/rsa_internal.o
+CC build_out/hosal/bl602_hal/hosal_wdg.o
+CC build_out/mbedtls_lts/mbedtls/library/sha1.o
+AR build_out/vfs/libvfs.a
+CC build_out/utils/src/utils_hmac_sha1_fast.o
+CC build_out/utils/src/utils_psk_fast.o
+CXX build_out/hosal/platform_hal/platform_hal_device.o
+CC build_out/utils/src/utils_memp.o
+CC build_out/utils/src/utils_tlv_bl.o
+CC build_out/mbedtls_lts/mbedtls/library/sha256.o
+CC build_out/mbedtls_lts/mbedtls/library/sha512.o
+CC build_out/utils/src/utils_base64.o
+CC build_out/utils/src/utils_bitmap_window.o
+CC build_out/hosal/bl602_hal/hosal_uart.o
+CC build_out/utils/src/test/test_utils_base64.o
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/platform/hosal/bl602_hal/hosal_uart.c: In function 'gpio_init_only_tx':
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/platform/hosal/bl602_hal/hosal_uart.c:60:38: warning: variable 'rx_sigfun' set but not used [-Wunused-but-set-variable]
+   60 |     GLB_UART_SIG_FUN_Type tx_sigfun, rx_sigfun;
+      |                                      ^~~~~~~~~
+CC build_out/utils/src/test/test_utils_ringblk.o
+CC build_out/utils/src/test/test_utils_bitmap_window.o
+CC build_out/mbedtls_lts/mbedtls/library/ssl_cache.o
+CC build_out/mbedtls_lts/mbedtls/library/ssl_ciphersuites.o
+CC build_out/mbedtls_lts/mbedtls/library/ssl_cli.o
+CC build_out/hosal/bl602_hal/hosal_dma.o
+CC build_out/mbedtls_lts/mbedtls/library/ssl_cookie.o
+CC build_out/lwip/src/core/ipv4/etharp.o
+CC build_out/hosal/bl602_hal/hosal_flash.o
+CC build_out/lwip/src/core/ipv4/icmp.o
+AR build_out/utils/libutils.a
+CC build_out/lwip/src/core/ipv4/igmp.o
+CC build_out/lwip/src/core/ipv4/ip4.o
+CC build_out/hosal/bl602_hal/hosal_dac.o
+CC build_out/lwip/src/core/ipv4/ip4_addr.o
+CC build_out/mbedtls_lts/mbedtls/library/ssl_msg.o
+CC build_out/lwip/src/core/ipv4/ip4_frag.o
+CC build_out/mbedtls_lts/mbedtls/library/ssl_srv.o
+CC build_out/lwip/src/core/mem.o
+CC build_out/lwip/src/core/memp.o
+CC build_out/mbedtls_lts/mbedtls/library/ssl_ticket.o
+CC build_out/lwip/src/core/netif.o
+CC build_out/mbedtls_lts/mbedtls/library/ssl_tls13_keys.o
+CC build_out/mbedtls_lts/mbedtls/library/ssl_tls.o
+CC build_out/hosal/bl602_hal/hosal_i2c.o
+CC build_out/lwip/src/core/pbuf.o
+CC build_out/lwip/src/core/raw.o
+CC build_out/lwip/src/core/stats.o
+CC build_out/mbedtls_lts/mbedtls/library/threading.o
+CC build_out/lwip/src/core/sys.o
+CC build_out/mbedtls_lts/mbedtls/library/timing.o
+CC build_out/hosal/bl602_hal/hosal_ota.o
+CC build_out/mbedtls_lts/mbedtls/library/version.o
+CC build_out/lwip/src/core/tcp.o
+CC build_out/lwip/src/core/tcp_in.o
+CC build_out/mbedtls_lts/mbedtls/library/version_features.o
+CC build_out/hosal/bl602_hal/hosal_timer.o
+CC build_out/hosal/bl602_hal/hosal_efuse.o
+CC build_out/mbedtls_lts/mbedtls/library/x509.o
+CC build_out/hosal/sec_common/bl_sec_sha.o
+CC build_out/hosal/sec_common/bl_sec_pka.o
+CC build_out/hosal/sec_common/bl_sec_aes.o
+CC build_out/hosal/sec_common/bl_sec_gmac.o
+CC build_out/mbedtls_lts/mbedtls/library/x509_create.o
+CC build_out/mbedtls_lts/mbedtls/library/x509_crl.o
+CC build_out/lwip/src/core/tcp_out.o
+CC build_out/lwip/src/core/timeouts.o
+CC build_out/mbedtls_lts/mbedtls/library/x509_crt.o
+AR build_out/hosal/libhosal.a
+CC build_out/mbedtls_lts/mbedtls/library/x509_csr.o
+CC build_out/lwip/src/core/udp.o
+CC build_out/lwip/src/core/utils.o
+CC build_out/mbedtls_lts/mbedtls/library/x509write_crt.o
+CC build_out/mbedtls_lts/mbedtls/library/x509write_csr.o
+CC build_out/lwip/src/netif/bridgeif.o
+CC build_out/mbedtls_lts/port/pkparse.o
+CC build_out/mbedtls_lts/port/mbedtls_port_mem.o
+CC build_out/lwip/src/netif/bridgeif_fdb.o
+CC build_out/mbedtls_lts/port/net_sockets.o
+CC build_out/mbedtls_lts/port/hw_entropy_poll.o
+CC build_out/lwip/src/netif/ethernet.o
+CC build_out/mbedtls_lts/port/bignum_ext.o
+CC build_out/mbedtls_lts/mbedtls/library/bignum.o
+CC build_out/lwip/src/netif/lowpan6.o
+CC build_out/lwip/src/netif/lowpan6_ble.o
+CC build_out/mbedtls_lts/port/test_case.o
+CC build_out/lwip/src/netif/lowpan6_common.o
+CC build_out/lwip/src/netif/slipif.o
+CC build_out/lwip/src/netif/zepif.o
+AR build_out/lwip/liblwip.a
+AR build_out/mbedtls_lts/libmbedtls_lts.a
+LD build_out/helloworld.elf
+Generating BIN File to /home/fae/codex-builds/Ai-Thinker-WB2-2420da7/applications/get-started/helloworld/build_out/helloworld.bin
+Building Finish. To flash build output. run 'make flash' or:
+c  ...
+cd /home/fae/codex-builds/Ai-Thinker-WB2-2420da7/tools/flash_tool && env SDK_APP_BIN=/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/applications/get-started/helloworld/build_out/helloworld.bin SDK_BOARD=evb SDK_NAME=helloworld SDK_MEDIA_BIN= SDK_ROMFS_DIR= SDK_DTS= SDK_XTAL= BL_FLASH_TOOL_INPUT_PATH_cfg2_bin_input=/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/applications/get-started/helloworld/build_out/helloworld.bin ./bflb_iot_tool-ubuntu --chipname=BL602 --baudrate=921600 --port=/dev/ttyUSB0 --pt=/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/applications/get-started/helloworld/img_conf/partition_cfg_2M.toml --dts=/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/applications/get-started/helloworld/img_conf/bl_factory_params_IoTKitA_40M.dts --firmware=/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/applications/get-started/helloworld/build_out/helloworld.bin
+ELAPSED_SECONDS=5.37

--- a/docs/build-logs/Ai-Thinker-WB2-helloworld-clean-build-2.log
+++ b/docs/build-logs/Ai-Thinker-WB2-helloworld-clean-build-2.log
@@ -1,0 +1,430 @@
+Your configuration chipname is Ai-Thinker Ai-WB2 Wi-Fi&BLE Module
+RM libromfs.a src/bl_romfs.o src/bl_romfs.d component_project_vars.mk
+RM libvfs.a src/vfs.o src/vfs_file.o src/vfs_inode.o src/vfs_register.o device/vfs_uart.o device/vfs_adc.o device/vfs_spi.o device/vfs_gpio.o device/vfs_pwm.o src/vfs.d src/vfs_file.d src/vfs_inode.d src/vfs_register.d device/vfs_uart.d device/vfs_adc.d device/vfs_spi.d device/vfs_gpio.d device/vfs_pwm.d component_project_vars.mk
+RM libnewlibc.a ./syscalls.o ./assert.o ./syscalls.d ./assert.d component_project_vars.mk
+RM liblwip.a lwip-port/FreeRTOS/ethernetif.o lwip-port/FreeRTOS/sys_arch.o src/api/api_lib.o src/api/api_msg.o src/api/err.o src/api/if_api.o src/api/netbuf.o src/api/netdb.o src/api/netifapi.o src/api/sockets.o src/api/tcpip.o src/apps/altcp_tls/altcp_tls_mbedtls.o src/apps/altcp_tls/altcp_tls_mbedtls_mem.o src/core/altcp.o src/core/altcp_alloc.o src/core/altcp_tcp.o src/core/def.o src/core/dns.o src/core/inet_chksum.o src/core/init.o src/core/ip.o src/core/ipv4/autoip.o src/core/ipv4/dhcp.o src/core/ipv4/etharp.o src/core/ipv4/icmp.o src/core/ipv4/igmp.o src/core/ipv4/ip4.o src/core/ipv4/ip4_addr.o src/core/ipv4/ip4_frag.o src/core/mem.o src/core/memp.o src/core/netif.o src/core/pbuf.o src/core/raw.o src/core/stats.o src/core/sys.o src/core/tcp.o src/core/tcp_in.o src/core/tcp_out.o src/core/timeouts.o src/core/udp.o src/core/utils.o src/netif/bridgeif.o src/netif/bridgeif_fdb.o src/netif/ethernet.o src/netif/lowpan6.o src/netif/lowpan6_ble.o src/netif/lowpan6_common.o src/netif/slipif.o src/netif/zepif.o lwip-port/FreeRTOS/ethernetif.d lwip-port/FreeRTOS/sys_arch.d src/api/api_lib.d src/api/api_msg.d src/api/err.d src/api/if_api.d src/api/netbuf.d src/api/netdb.d src/api/netifapi.d src/api/sockets.d src/api/tcpip.d src/apps/altcp_tls/altcp_tls_mbedtls.d src/apps/altcp_tls/altcp_tls_mbedtls_mem.d src/core/altcp.d src/core/altcp_alloc.d src/core/altcp_tcp.d src/core/def.d src/core/dns.d src/core/inet_chksum.d src/core/init.d src/core/ip.d src/core/ipv4/autoip.d src/core/ipv4/dhcp.d src/core/ipv4/etharp.d src/core/ipv4/icmp.d src/core/ipv4/igmp.d src/core/ipv4/ip4.d src/core/ipv4/ip4_addr.d src/core/ipv4/ip4_frag.d src/core/mem.d src/core/memp.d src/core/netif.d src/core/pbuf.d src/core/raw.d src/core/stats.d src/core/sys.d src/core/tcp.d src/core/tcp_in.d src/core/tcp_out.d src/core/timeouts.d src/core/udp.d src/core/utils.d src/netif/bridgeif.d src/netif/bridgeif_fdb.d src/netif/ethernet.d src/netif/lowpan6.d src/netif/lowpan6_ble.d src/netif/lowpan6_common.d src/netif/slipif.d src/netif/zepif.d component_project_vars.mk
+RM libhosal.a adapter/hosal_adpt_iotsdk.o bl602_hal/bl_uart.o bl602_hal/bl_chip.o bl602_hal/bl_cks.o bl602_hal/bl_sys.o bl602_hal/bl_sys_cli.o bl602_hal/bl_dma.o bl602_hal/bl_irq.o bl602_hal/bl_sec.o bl602_hal/bl_ir.o bl602_hal/bl_boot2.o bl602_hal/bl_timer.o bl602_hal/bl_hbn.o bl602_hal/bl_efuse.o bl602_hal/bl_flash.o bl602_hal/bl_gpio.o bl602_hal/bl_gpio_cli.o bl602_hal/hal_gpio.o bl602_hal/hal_button.o bl602_hal/bl_pwm.o bl602_hal/bl_sec_aes.o bl602_hal/bl_wifi.o bl602_hal/bl_wdt.o bl602_hal/bl_wdt_cli.o bl602_hal/bl_clocktree.o bl602_hal/hal_boot2.o bl602_hal/hal_sys.o bl602_hal/hal_board.o bl602_hal/hal_ir.o bl602_hal/bl_adc.o bl602_hal/bl_dac_audio.o bl602_hal/bl_i2c.o bl602_hal/bl_pm.o bl602_hal/bl_pds.o bl602_hal/hosal_pwm.o bl602_hal/hal_pds.o bl602_hal/hosal_rng.o bl602_hal/bl_rtc.o bl602_hal/hal_hbn.o bl602_hal/hal_hbnram.o bl602_hal/hosal_rtc.o bl602_hal/hosal_gpio.o bl602_hal/hosal_adc.o bl602_hal/hosal_spi.o bl602_hal/hal_hwtimer.o bl602_hal/hal_wifi.o bl602_hal/hosal_wdg.o platform_hal/platform_hal_device.o bl602_hal/hosal_uart.o bl602_hal/hosal_dma.o bl602_hal/hosal_flash.o bl602_hal/hosal_dac.o bl602_hal/hosal_i2c.o bl602_hal/hosal_ota.o bl602_hal/hosal_timer.o bl602_hal/hosal_efuse.o sec_common/bl_sec_sha.o sec_common/bl_sec_pka.o sec_common/bl_sec_aes.o sec_common/bl_sec_gmac.o adapter/hosal_adpt_iotsdk.d bl602_hal/bl_uart.d bl602_hal/bl_chip.d bl602_hal/bl_cks.d bl602_hal/bl_sys.d bl602_hal/bl_sys_cli.d bl602_hal/bl_dma.d bl602_hal/bl_irq.d bl602_hal/bl_sec.d bl602_hal/bl_ir.d bl602_hal/bl_boot2.d bl602_hal/bl_timer.d bl602_hal/bl_hbn.d bl602_hal/bl_efuse.d bl602_hal/bl_flash.d bl602_hal/bl_gpio.d bl602_hal/bl_gpio_cli.d bl602_hal/hal_gpio.d bl602_hal/hal_button.d bl602_hal/bl_pwm.d bl602_hal/bl_sec_aes.d bl602_hal/bl_wifi.d bl602_hal/bl_wdt.d bl602_hal/bl_wdt_cli.d bl602_hal/bl_clocktree.d bl602_hal/hal_boot2.d bl602_hal/hal_sys.d bl602_hal/hal_board.d bl602_hal/hal_ir.d bl602_hal/bl_adc.d bl602_hal/bl_dac_audio.d bl602_hal/bl_i2c.d bl602_hal/bl_pm.d bl602_hal/bl_pds.d bl602_hal/hosal_pwm.d bl602_hal/hal_pds.d bl602_hal/hosal_rng.d bl602_hal/bl_rtc.d bl602_hal/hal_hbn.d bl602_hal/hal_hbnram.d bl602_hal/hosal_rtc.d bl602_hal/hosal_gpio.d bl602_hal/hosal_adc.d bl602_hal/hosal_spi.d bl602_hal/hal_hwtimer.d bl602_hal/hal_wifi.d bl602_hal/hosal_wdg.d platform_hal/platform_hal_device.d bl602_hal/hosal_uart.d bl602_hal/hosal_dma.d bl602_hal/hosal_flash.d bl602_hal/hosal_dac.d bl602_hal/hosal_i2c.d bl602_hal/hosal_ota.d bl602_hal/hosal_timer.d bl602_hal/hosal_efuse.d sec_common/bl_sec_sha.d sec_common/bl_sec_pka.d sec_common/bl_sec_aes.d sec_common/bl_sec_gmac.d component_project_vars.mk
+RM libbl602.a evb/src/boot/gcc/entry.o evb/src/boot/gcc/start.o evb/src/debug.o evb/src/strntoumax.o bfl_main.o evb/src/boot/gcc/entry.d evb/src/boot/gcc/start.d evb/src/debug.d evb/src/strntoumax.d bfl_main.d component_project_vars.mk
+RM libbl602_std.a bl602_std/StdDriver/Src/bl602_uart.o bl602_std/StdDriver/Src/bl602_adc.o bl602_std/StdDriver/Src/bl602_sec_eng.o bl602_std/StdDriver/Src/bl602_dma.o bl602_std/StdDriver/Src/bl602_common.o bl602_std/StdDriver/Src/bl602_glb.o bl602_std/StdDriver/Src/bl602_hbn.o bl602_std/StdDriver/Src/bl602_timer.o bl602_std/StdDriver/Src/bl602_aon.o bl602_std/StdDriver/Src/bl602_pds.o bl602_std/StdDriver/Src/bl602_pwm.o bl602_std/StdDriver/Src/bl602_l1c.o bl602_std/StdDriver/Src/bl602_ef_ctrl.o bl602_std/StdDriver/Src/bl602_mfg_efuse.o bl602_std/StdDriver/Src/bl602_mfg_flash.o bl602_std/StdDriver/Src/bl602_mfg_media.o bl602_std/StdDriver/Src/bl602_dac.o bl602_std/StdDriver/Src/bl602_ir.o bl602_std/StdDriver/Src/bl602_spi.o bl602_std/StdDriver/Src/bl602_i2c.o bl602_std/StdDriver/Src/bl602_sdu.o bl602_std/Common/soft_crc/softcrc.o bl602_std/Common/xz/xz_crc32.o bl602_std/Common/xz/xz_dec_lzma2.o bl602_std/Common/xz/xz_dec_stream.o bl602_std/Common/xz/xz_decompress.o bl602_std/Common/xz/xz_port.o bl602_std/Common/cipher_suite/src/bflb_crypt.o bl602_std/Common/cipher_suite/src/bflb_hash.o bl602_std/Common/cipher_suite/src/bflb_dsa.o bl602_std/Common/cipher_suite/src/bflb_ecdsa.o bl602_std/Common/platform_print/platform_device.o bl602_std/Common/platform_print/platform_gpio.o bl602_std/Common/ring_buffer/ring_buffer.o bl602_std/RISCV/Device/Bouffalo/BL602/Startup/interrupt.o bl602_std/StdDriver/Src/bl602_romapi.o bl602_std/StdDriver/Src/bl602_sflash_ext.o bl602_std/StdDriver/Src/bl602_sf_cfg_ext.o bl602_std/StdDriver/Src/bl602_xip_sflash_ext.o bl602_std/StdDriver/Src/bl602_uart.d bl602_std/StdDriver/Src/bl602_adc.d bl602_std/StdDriver/Src/bl602_sec_eng.d bl602_std/StdDriver/Src/bl602_dma.d bl602_std/StdDriver/Src/bl602_common.d bl602_std/StdDriver/Src/bl602_glb.d bl602_std/StdDriver/Src/bl602_hbn.d bl602_std/StdDriver/Src/bl602_timer.d bl602_std/StdDriver/Src/bl602_aon.d bl602_std/StdDriver/Src/bl602_pds.d bl602_std/StdDriver/Src/bl602_pwm.d bl602_std/StdDriver/Src/bl602_l1c.d bl602_std/StdDriver/Src/bl602_ef_ctrl.d bl602_std/StdDriver/Src/bl602_mfg_efuse.d bl602_std/StdDriver/Src/bl602_mfg_flash.d bl602_std/StdDriver/Src/bl602_mfg_media.d bl602_std/StdDriver/Src/bl602_dac.d bl602_std/StdDriver/Src/bl602_ir.d bl602_std/StdDriver/Src/bl602_spi.d bl602_std/StdDriver/Src/bl602_i2c.d bl602_std/StdDriver/Src/bl602_sdu.d bl602_std/Common/soft_crc/softcrc.d bl602_std/Common/xz/xz_crc32.d bl602_std/Common/xz/xz_dec_lzma2.d bl602_std/Common/xz/xz_dec_stream.d bl602_std/Common/xz/xz_decompress.d bl602_std/Common/xz/xz_port.d bl602_std/Common/cipher_suite/src/bflb_crypt.d bl602_std/Common/cipher_suite/src/bflb_hash.d bl602_std/Common/cipher_suite/src/bflb_dsa.d bl602_std/Common/cipher_suite/src/bflb_ecdsa.d bl602_std/Common/platform_print/platform_device.d bl602_std/Common/platform_print/platform_gpio.d bl602_std/Common/ring_buffer/ring_buffer.d bl602_std/RISCV/Device/Bouffalo/BL602/Startup/interrupt.d bl602_std/StdDriver/Src/bl602_romapi.d bl602_std/StdDriver/Src/bl602_sflash_ext.d bl602_std/StdDriver/Src/bl602_sf_cfg_ext.d bl602_std/StdDriver/Src/bl602_xip_sflash_ext.d component_project_vars.mk
+RM libfreertos_riscv_ram.a event_groups.o list.o queue.o stream_buffer.o tasks.o timers.o misaligned/misaligned_ldst.o misaligned/fp_asm.o panic/panic_c.o portable/GCC/RISC-V/port.o portable/GCC/RISC-V/portASM.o portable/MemMang/heap_5.o event_groups.d list.d queue.d stream_buffer.d tasks.d timers.d misaligned/misaligned_ldst.d misaligned/fp_asm.d panic/panic_c.d portable/GCC/RISC-V/port.d portable/GCC/RISC-V/portASM.d portable/MemMang/heap_5.d component_project_vars.mk
+RM libmbedtls_lts.a mbedtls/library/xtea.o mbedtls/library/aes.o mbedtls/library/aesni.o mbedtls/library/arc4.o mbedtls/library/aria.o mbedtls/library/asn1parse.o mbedtls/library/asn1write.o mbedtls/library/base64.o mbedtls/library/blowfish.o mbedtls/library/camellia.o mbedtls/library/ccm.o mbedtls/library/certs.o mbedtls/library/chacha20.o mbedtls/library/chachapoly.o mbedtls/library/cipher.o mbedtls/library/cipher_wrap.o mbedtls/library/cmac.o mbedtls/library/constant_time.o mbedtls/library/ctr_drbg.o mbedtls/library/debug.o mbedtls/library/des.o mbedtls/library/dhm.o mbedtls/library/ecdh.o mbedtls/library/ecdsa.o mbedtls/library/ecjpake.o mbedtls/library/ecp.o mbedtls/library/ecp_curves.o mbedtls/library/entropy.o mbedtls/library/entropy_poll.o mbedtls/library/error.o mbedtls/library/gcm.o mbedtls/library/havege.o mbedtls/library/hkdf.o mbedtls/library/hmac_drbg.o mbedtls/library/md2.o mbedtls/library/md4.o mbedtls/library/md5.o mbedtls/library/md.o mbedtls/library/memory_buffer_alloc.o mbedtls/library/mps_reader.o mbedtls/library/mps_trace.o mbedtls/library/nist_kw.o mbedtls/library/oid.o mbedtls/library/padlock.o mbedtls/library/pem.o mbedtls/library/pk.o mbedtls/library/pkcs11.o mbedtls/library/pkcs12.o mbedtls/library/pkcs5.o mbedtls/library/pk_wrap.o mbedtls/library/pkwrite.o mbedtls/library/platform.o mbedtls/library/platform_util.o mbedtls/library/poly1305.o mbedtls/library/ripemd160.o mbedtls/library/rsa.o mbedtls/library/rsa_internal.o mbedtls/library/sha1.o mbedtls/library/sha256.o mbedtls/library/sha512.o mbedtls/library/ssl_cache.o mbedtls/library/ssl_ciphersuites.o mbedtls/library/ssl_cli.o mbedtls/library/ssl_cookie.o mbedtls/library/ssl_msg.o mbedtls/library/ssl_srv.o mbedtls/library/ssl_ticket.o mbedtls/library/ssl_tls13_keys.o mbedtls/library/ssl_tls.o mbedtls/library/threading.o mbedtls/library/timing.o mbedtls/library/version.o mbedtls/library/version_features.o mbedtls/library/x509.o mbedtls/library/x509_create.o mbedtls/library/x509_crl.o mbedtls/library/x509_crt.o mbedtls/library/x509_csr.o mbedtls/library/x509write_crt.o mbedtls/library/x509write_csr.o port/pkparse.o port/mbedtls_port_mem.o port/net_sockets.o port/hw_entropy_poll.o port/bignum_ext.o mbedtls/library/bignum.o port/test_case.o mbedtls/library/xtea.d mbedtls/library/aes.d mbedtls/library/aesni.d mbedtls/library/arc4.d mbedtls/library/aria.d mbedtls/library/asn1parse.d mbedtls/library/asn1write.d mbedtls/library/base64.d mbedtls/library/blowfish.d mbedtls/library/camellia.d mbedtls/library/ccm.d mbedtls/library/certs.d mbedtls/library/chacha20.d mbedtls/library/chachapoly.d mbedtls/library/cipher.d mbedtls/library/cipher_wrap.d mbedtls/library/cmac.d mbedtls/library/constant_time.d mbedtls/library/ctr_drbg.d mbedtls/library/debug.d mbedtls/library/des.d mbedtls/library/dhm.d mbedtls/library/ecdh.d mbedtls/library/ecdsa.d mbedtls/library/ecjpake.d mbedtls/library/ecp.d mbedtls/library/ecp_curves.d mbedtls/library/entropy.d mbedtls/library/entropy_poll.d mbedtls/library/error.d mbedtls/library/gcm.d mbedtls/library/havege.d mbedtls/library/hkdf.d mbedtls/library/hmac_drbg.d mbedtls/library/md2.d mbedtls/library/md4.d mbedtls/library/md5.d mbedtls/library/md.d mbedtls/library/memory_buffer_alloc.d mbedtls/library/mps_reader.d mbedtls/library/mps_trace.d mbedtls/library/nist_kw.d mbedtls/library/oid.d mbedtls/library/padlock.d mbedtls/library/pem.d mbedtls/library/pk.d mbedtls/library/pkcs11.d mbedtls/library/pkcs12.d mbedtls/library/pkcs5.d mbedtls/library/pk_wrap.d mbedtls/library/pkwrite.d mbedtls/library/platform.d mbedtls/library/platform_util.d mbedtls/library/poly1305.d mbedtls/library/ripemd160.d mbedtls/library/rsa.d mbedtls/library/rsa_internal.d mbedtls/library/sha1.d mbedtls/library/sha256.d mbedtls/library/sha512.d mbedtls/library/ssl_cache.d mbedtls/library/ssl_ciphersuites.d mbedtls/library/ssl_cli.d mbedtls/library/ssl_cookie.d mbedtls/library/ssl_msg.d mbedtls/library/ssl_srv.d mbedtls/library/ssl_ticket.d mbedtls/library/ssl_tls13_keys.d mbedtls/library/ssl_tls.d mbedtls/library/threading.d mbedtls/library/timing.d mbedtls/library/version.d mbedtls/library/version_features.d mbedtls/library/x509.d mbedtls/library/x509_create.d mbedtls/library/x509_crl.d mbedtls/library/x509_crt.d mbedtls/library/x509_csr.d mbedtls/library/x509write_crt.d mbedtls/library/x509write_csr.d port/pkparse.d port/mbedtls_port_mem.d port/net_sockets.d port/hw_entropy_poll.d port/bignum_ext.d mbedtls/library/bignum.d port/test_case.d component_project_vars.mk
+RM libblfdt.a src/fdt.o src/fdt_ro.o src/fdt_wip.o src/fdt_sw.o src/fdt_rw.o src/fdt_strerror.o src/fdt_empty_tree.o src/fdt_addresses.o src/fdt_overlay.o test/tc_blfdt_dump.o test/tc_blfdt_wifi.o test/blfdt_cli_test.o src/fdt.d src/fdt_ro.d src/fdt_wip.d src/fdt_sw.d src/fdt_rw.d src/fdt_strerror.d src/fdt_empty_tree.d src/fdt_addresses.d src/fdt_overlay.d test/tc_blfdt_dump.d test/tc_blfdt_wifi.d test/blfdt_cli_test.d component_project_vars.mk
+RM libblog.a ./blog.o ./blog.d component_project_vars.mk
+RM libblog_testc.a blog_testc.o blog_testc1_diable.o blog_testc2_full.o blog_testc3_nopri.o blog_testc4_onlypri.o blog_testc.d blog_testc1_diable.d blog_testc2_full.d blog_testc3_nopri.d blog_testc4_onlypri.d component_project_vars.mk
+RM libcli.a cli/cli.o cli/cli.d component_project_vars.mk
+RM libcoredump.a bl_coredump.o bl_coredump.d component_project_vars.mk
+RM libyloop.a src/yloop.o src/select.o src/aos_freertos.o src/device.o src/local_event.o src/yloop.d src/select.d src/aos_freertos.d src/device.d src/local_event.d component_project_vars.mk
+RM libblmtd.a bl_mtd.o bl_mtd.d component_project_vars.mk
+RM libbloop.a src/bloop_base.o src/bloop_handler_sys.o src/bloop_base.d src/bloop_handler_sys.d component_project_vars.mk
+RM liblooprt.a src/looprt.o src/looprt_test_cli.o src/looprt.d src/looprt_test_cli.d component_project_vars.mk
+RM libloopset.a src/loopset_led.o src/loopset_led_cli.o src/loopset_ir.o src/loopset_pwm.o src/loopset_led.d src/loopset_led_cli.d src/loopset_ir.d src/loopset_pwm.d component_project_vars.mk
+RM libbltime.a bl_sys_time.o bl_sys_time_cli.o bl_sys_time.d bl_sys_time_cli.d component_project_vars.mk
+RM libutils.a src/utils_hex.o src/utils_crc.o src/utils_sha256.o src/utils_fec.o src/utils_log.o src/utils_dns.o src/utils_list.o src/utils_ringblk.o src/utils_rbtree.o src/utils_hexdump.o src/utils_time.o src/utils_notifier.o src/utils_getopt.o src/utils_string.o src/utils_hmac_sha1_fast.o src/utils_psk_fast.o src/utils_memp.o src/utils_tlv_bl.o src/utils_base64.o src/utils_bitmap_window.o src/test/test_utils_base64.o src/test/test_utils_ringblk.o src/test/test_utils_bitmap_window.o src/utils_hex.d src/utils_crc.d src/utils_sha256.d src/utils_fec.d src/utils_log.d src/utils_dns.d src/utils_list.d src/utils_ringblk.d src/utils_rbtree.d src/utils_hexdump.d src/utils_time.d src/utils_notifier.d src/utils_getopt.d src/utils_string.d src/utils_hmac_sha1_fast.d src/utils_psk_fast.d src/utils_memp.d src/utils_tlv_bl.d src/utils_base64.d src/utils_bitmap_window.d src/test/test_utils_base64.d src/test/test_utils_ringblk.d src/test/test_utils_bitmap_window.d component_project_vars.mk
+RM libhelloworld.a ./main.o ./main.d component_project_vars.mk
+RM /home/fae/codex-builds/Ai-Thinker-WB2-2420da7/applications/get-started/helloworld/build_out/helloworld.elf
+Your configuration chipname is Ai-Thinker Ai-WB2 Wi-Fi&BLE Module
+Your configuration chipname is Ai-Thinker Ai-WB2 Wi-Fi&BLE Module
+AS build_out/bl602/evb/src/boot/gcc/entry.o
+AS build_out/bl602/evb/src/boot/gcc/start.o
+CC build_out/bl602/evb/src/debug.o
+CC build_out/bl602/evb/src/strntoumax.o
+CC build_out/blfdt/src/fdt.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_uart.o
+CC build_out/blmtd/bl_mtd.o
+CC build_out/blog/blog.o
+CC build_out/bl602/bfl_main.o
+CC build_out/blog_testc/blog_testc.o
+CC build_out/blog_testc/blog_testc1_diable.o
+CC build_out/blfdt/src/fdt_ro.o
+AR build_out/blmtd/libblmtd.a
+CC build_out/blog_testc/blog_testc2_full.o
+CC build_out/bloop/src/bloop_base.o
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/stage/blog_testc/blog_testc2_full.c: In function 'test_buf':
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/stage/blog_testc/blog_testc2_full.c:18:364: warning: conversion from 'unsigned int' to 'uint8_t' {aka 'unsigned char'} changes value from '256' to '0' [-Woverflow]
+   18 |     blog_debug_hexdump("hexdumpbuf", buf, sizeof(buf));
+      |                                                                                                                                                                                                                                                                                                                                                                            ^          
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/stage/blog_testc/blog_testc2_full.c:19:368: warning: conversion from 'unsigned int' to 'uint8_t' {aka 'unsigned char'} changes value from '256' to '0' [-Woverflow]
+   19 |     blog_info_hexdump("hexdumpbuf", buf, sizeof(buf));
+      |                                                                                                                                                                                                                                                                                                                                                                                ^          
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/stage/blog_testc/blog_testc2_full.c:20:368: warning: conversion from 'unsigned int' to 'uint8_t' {aka 'unsigned char'} changes value from '256' to '0' [-Woverflow]
+   20 |     blog_warn_hexdump("hexdumpbuf", buf, sizeof(buf));
+      |                                                                                                                                                                                                                                                                                                                                                                                ^          
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/stage/blog_testc/blog_testc2_full.c:21:371: warning: conversion from 'unsigned int' to 'uint8_t' {aka 'unsigned char'} changes value from '256' to '0' [-Woverflow]
+   21 |     blog_error_hexdump("hexdumpbuf", buf, sizeof(buf));
+      |                                                                                                                                                                                                                                                                                                                                                                                   ^          
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/stage/blog_testc/blog_testc2_full.c:22:372: warning: conversion from 'unsigned int' to 'uint8_t' {aka 'unsigned char'} changes value from '256' to '0' [-Woverflow]
+   22 |     blog_assert_hexdump("hexdumpbuf", buf, sizeof(buf));
+      |                                                                                                                                                                                                                                                                                                                                                                                    ^          
+CC build_out/blfdt/src/fdt_wip.o
+CC build_out/blfdt/src/fdt_sw.o
+AR build_out/blog/libblog.a
+CC build_out/blfdt/src/fdt_rw.o
+CC build_out/blfdt/src/fdt_strerror.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_adc.o
+CC build_out/blog_testc/blog_testc3_nopri.o
+CC build_out/blfdt/src/fdt_empty_tree.o
+CC build_out/blog_testc/blog_testc4_onlypri.o
+CC build_out/blfdt/src/fdt_addresses.o
+CC build_out/blfdt/src/fdt_overlay.o
+CC build_out/bloop/src/bloop_handler_sys.o
+CC build_out/blfdt/test/tc_blfdt_dump.o
+AR build_out/bloop/libbloop.a
+AR build_out/blog_testc/libblog_testc.a
+AR build_out/bl602/libbl602.a
+CC build_out/blfdt/test/tc_blfdt_wifi.o
+CC build_out/blfdt/test/blfdt_cli_test.o
+CC build_out/bltime/bl_sys_time.o
+CC build_out/bltime/bl_sys_time_cli.o
+CC build_out/cli/cli/cli.o
+CC build_out/coredump/bl_coredump.o
+CC build_out/freertos_riscv_ram/event_groups.o
+AR build_out/bltime/libbltime.a
+CC build_out/freertos_riscv_ram/list.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_sec_eng.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_dma.o
+CC build_out/helloworld/main.o
+AR build_out/blfdt/libblfdt.a
+CC build_out/hosal/adapter/hosal_adpt_iotsdk.o
+CC build_out/looprt/src/looprt.o
+CC build_out/hosal/bl602_hal/bl_uart.o
+AR build_out/helloworld/libhelloworld.a
+CC build_out/hosal/bl602_hal/bl_chip.o
+AR build_out/coredump/libcoredump.a
+CC build_out/hosal/bl602_hal/bl_cks.o
+CC build_out/looprt/src/looprt_test_cli.o
+CC build_out/freertos_riscv_ram/queue.o
+CC build_out/hosal/bl602_hal/bl_sys.o
+AR build_out/looprt/liblooprt.a
+CC build_out/hosal/bl602_hal/bl_sys_cli.o
+CC build_out/hosal/bl602_hal/bl_dma.o
+CC build_out/hosal/bl602_hal/bl_irq.o
+CC build_out/hosal/bl602_hal/bl_sec.o
+CC build_out/hosal/bl602_hal/bl_ir.o
+CC build_out/freertos_riscv_ram/stream_buffer.o
+CC build_out/hosal/bl602_hal/bl_boot2.o
+CC build_out/hosal/bl602_hal/bl_timer.o
+AR build_out/cli/libcli.a
+CC build_out/hosal/bl602_hal/bl_hbn.o
+CC build_out/freertos_riscv_ram/tasks.o
+CC build_out/hosal/bl602_hal/bl_efuse.o
+CC build_out/hosal/bl602_hal/bl_flash.o
+CC build_out/freertos_riscv_ram/timers.o
+CC build_out/hosal/bl602_hal/bl_gpio.o
+CC build_out/hosal/bl602_hal/bl_gpio_cli.o
+CC build_out/hosal/bl602_hal/hal_gpio.o
+CC build_out/loopset/src/loopset_led.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_common.o
+CC build_out/hosal/bl602_hal/hal_button.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_glb.o
+CC build_out/hosal/bl602_hal/bl_pwm.o
+CC build_out/loopset/src/loopset_led_cli.o
+CC build_out/loopset/src/loopset_ir.o
+CC build_out/freertos_riscv_ram/misaligned/misaligned_ldst.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_hbn.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_timer.o
+CC build_out/hosal/bl602_hal/bl_sec_aes.o
+CC build_out/loopset/src/loopset_pwm.o
+AS build_out/freertos_riscv_ram/misaligned/fp_asm.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_aon.o
+AR build_out/loopset/libloopset.a
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_pds.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_pwm.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_l1c.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_ef_ctrl.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_mfg_efuse.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_mfg_flash.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_mfg_media.o
+CC build_out/hosal/bl602_hal/bl_wifi.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_dac.o
+CC build_out/freertos_riscv_ram/panic/panic_c.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_ir.o
+CC build_out/hosal/bl602_hal/bl_wdt.o
+CC build_out/freertos_riscv_ram/portable/GCC/RISC-V/port.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_spi.o
+AS build_out/freertos_riscv_ram/portable/GCC/RISC-V/portASM.o
+CC build_out/hosal/bl602_hal/bl_wdt_cli.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_i2c.o
+CC build_out/freertos_riscv_ram/portable/MemMang/heap_5.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_sdu.o
+CC build_out/hosal/bl602_hal/bl_clocktree.o
+CC build_out/bl602_std/bl602_std/Common/soft_crc/softcrc.o
+CC build_out/bl602_std/bl602_std/Common/xz/xz_crc32.o
+CC build_out/hosal/bl602_hal/hal_boot2.o
+CC build_out/hosal/bl602_hal/hal_sys.o
+AR build_out/freertos_riscv_ram/libfreertos_riscv_ram.a
+CC build_out/lwip/lwip-port/FreeRTOS/ethernetif.o
+CC build_out/bl602_std/bl602_std/Common/xz/xz_dec_lzma2.o
+CC build_out/lwip/lwip-port/FreeRTOS/sys_arch.o
+CC build_out/lwip/src/api/api_lib.o
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/platform/hosal/bl602_hal/hal_sys.c: In function 'hal_sys_romapi_get':
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/platform/hosal/bl602_hal/hal_sys.c:40:65: warning: array subscript 88 is outside array bounds of 'uint8_t[1]' {aka 'unsigned char[1]'} [-Warray-bounds]
+   40 |     *(gp_data_start + 0) = (uint32_t)((uint8_t*)(gp_data_start) + 0x58);
+      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/platform/hosal/bl602_hal/hal_sys.c:29:20: note: while referencing '__global_pointer_head$'
+   29 |     extern uint8_t __global_pointer_head$;
+      |                    ^~~~~~~~~~~~~~~~~~~~~~
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/platform/hosal/bl602_hal/hal_sys.c:42:65: warning: array subscript 96 is outside array bounds of 'uint8_t[1]' {aka 'unsigned char[1]'} [-Warray-bounds]
+   42 |     *(gp_data_start + 1) = (uint32_t)((uint8_t*)(gp_data_start) + 0x60);
+      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/platform/hosal/bl602_hal/hal_sys.c:29:20: note: while referencing '__global_pointer_head$'
+   29 |     extern uint8_t __global_pointer_head$;
+      |                    ^~~~~~~~~~~~~~~~~~~~~~
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/platform/hosal/bl602_hal/hal_sys.c:42:5: warning: array subscript 1 is outside array bounds of 'uint8_t[1]' {aka 'unsigned char[1]'} [-Warray-bounds]
+   42 |     *(gp_data_start + 1) = (uint32_t)((uint8_t*)(gp_data_start) + 0x60);
+      |     ^~~~~~~~~~~~~~~~~~~~
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/platform/hosal/bl602_hal/hal_sys.c:29:20: note: while referencing '__global_pointer_head$'
+   29 |     extern uint8_t __global_pointer_head$;
+      |                    ^~~~~~~~~~~~~~~~~~~~~~
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/platform/hosal/bl602_hal/hal_sys.c:44:5: warning: array subscript 2 is outside array bounds of 'uint8_t[1]' {aka 'unsigned char[1]'} [-Warray-bounds]
+   44 |     *(gp_data_start + 2) = 32 * 1000 / 1000;//Use 32K
+      |     ^~~~~~~~~~~~~~~~~~~~
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/platform/hosal/bl602_hal/hal_sys.c:29:20: note: while referencing '__global_pointer_head$'
+   29 |     extern uint8_t __global_pointer_head$;
+      |                    ^~~~~~~~~~~~~~~~~~~~~~
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/platform/hosal/bl602_hal/hal_sys.c:37:21: warning: array subscript 1116 is outside array bounds of 'uint8_t[1]' {aka 'unsigned char[1]'} [-Warray-bounds]
+   37 |     romapi_freertos = (struct romapi_freertos_map*) (((uint8_t*)gp_data_start) + 0x45c);
+      |     ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/platform/hosal/bl602_hal/hal_sys.c:29:20: note: while referencing '__global_pointer_head$'
+   29 |     extern uint8_t __global_pointer_head$;
+      |                    ^~~~~~~~~~~~~~~~~~~~~~
+CC build_out/bl602_std/bl602_std/Common/xz/xz_dec_stream.o
+CC build_out/hosal/bl602_hal/hal_board.o
+CC build_out/hosal/bl602_hal/hal_ir.o
+CC build_out/hosal/bl602_hal/bl_adc.o
+CC build_out/hosal/bl602_hal/bl_dac_audio.o
+CC build_out/lwip/src/api/api_msg.o
+CC build_out/lwip/src/api/err.o
+CC build_out/lwip/src/api/if_api.o
+CC build_out/bl602_std/bl602_std/Common/xz/xz_decompress.o
+CC build_out/hosal/bl602_hal/bl_i2c.o
+CC build_out/hosal/bl602_hal/bl_pm.o
+CC build_out/bl602_std/bl602_std/Common/xz/xz_port.o
+CC build_out/bl602_std/bl602_std/Common/cipher_suite/src/bflb_crypt.o
+CC build_out/lwip/src/api/netbuf.o
+CC build_out/bl602_std/bl602_std/Common/cipher_suite/src/bflb_hash.o
+CC build_out/bl602_std/bl602_std/Common/cipher_suite/src/bflb_dsa.o
+CC build_out/hosal/bl602_hal/bl_pds.o
+CC build_out/hosal/bl602_hal/hosal_pwm.o
+CC build_out/hosal/bl602_hal/hal_pds.o
+CC build_out/lwip/src/api/netdb.o
+CC build_out/lwip/src/api/netifapi.o
+CC build_out/lwip/src/api/sockets.o
+CC build_out/bl602_std/bl602_std/Common/cipher_suite/src/bflb_ecdsa.o
+CC build_out/bl602_std/bl602_std/Common/platform_print/platform_device.o
+CC build_out/lwip/src/api/tcpip.o
+CC build_out/hosal/bl602_hal/hosal_rng.o
+CC build_out/hosal/bl602_hal/bl_rtc.o
+CC build_out/hosal/bl602_hal/hal_hbn.o
+CC build_out/lwip/src/apps/altcp_tls/altcp_tls_mbedtls.o
+CC build_out/hosal/bl602_hal/hal_hbnram.o
+CC build_out/hosal/bl602_hal/hosal_rtc.o
+CC build_out/lwip/src/apps/altcp_tls/altcp_tls_mbedtls_mem.o
+CC build_out/lwip/src/core/altcp.o
+CC build_out/hosal/bl602_hal/hosal_gpio.o
+CC build_out/hosal/bl602_hal/hosal_adc.o
+CC build_out/lwip/src/core/altcp_alloc.o
+CC build_out/bl602_std/bl602_std/Common/platform_print/platform_gpio.o
+CC build_out/lwip/src/core/altcp_tcp.o
+CC build_out/lwip/src/core/def.o
+CC build_out/bl602_std/bl602_std/Common/ring_buffer/ring_buffer.o
+CC build_out/hosal/bl602_hal/hosal_spi.o
+CC build_out/lwip/src/core/dns.o
+CC build_out/bl602_std/bl602_std/RISCV/Device/Bouffalo/BL602/Startup/interrupt.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_romapi.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_sflash_ext.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_sf_cfg_ext.o
+CC build_out/bl602_std/bl602_std/StdDriver/Src/bl602_xip_sflash_ext.o
+CC build_out/hosal/bl602_hal/hal_hwtimer.o
+CC build_out/hosal/bl602_hal/hal_wifi.o
+CC build_out/hosal/bl602_hal/hosal_wdg.o
+CXX build_out/hosal/platform_hal/platform_hal_device.o
+CC build_out/hosal/bl602_hal/hosal_uart.o
+CC build_out/hosal/bl602_hal/hosal_dma.o
+CC build_out/lwip/src/core/inet_chksum.o
+CC build_out/hosal/bl602_hal/hosal_flash.o
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/platform/hosal/bl602_hal/hosal_uart.c: In function 'gpio_init_only_tx':
+/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/components/platform/hosal/bl602_hal/hosal_uart.c:60:38: warning: variable 'rx_sigfun' set but not used [-Wunused-but-set-variable]
+   60 |     GLB_UART_SIG_FUN_Type tx_sigfun, rx_sigfun;
+      |                                      ^~~~~~~~~
+CC build_out/hosal/bl602_hal/hosal_dac.o
+CC build_out/hosal/bl602_hal/hosal_i2c.o
+CC build_out/lwip/src/core/init.o
+CC build_out/lwip/src/core/ip.o
+CC build_out/lwip/src/core/ipv4/autoip.o
+CC build_out/lwip/src/core/ipv4/dhcp.o
+CC build_out/hosal/bl602_hal/hosal_ota.o
+CC build_out/lwip/src/core/ipv4/etharp.o
+AR build_out/bl602_std/libbl602_std.a
+CC build_out/mbedtls_lts/mbedtls/library/xtea.o
+CC build_out/mbedtls_lts/mbedtls/library/aes.o
+CC build_out/hosal/bl602_hal/hosal_timer.o
+CC build_out/hosal/bl602_hal/hosal_efuse.o
+CC build_out/newlibc/syscalls.o
+CC build_out/newlibc/assert.o
+CC build_out/hosal/sec_common/bl_sec_sha.o
+CC build_out/romfs/src/bl_romfs.o
+CC build_out/utils/src/utils_hex.o
+CC build_out/utils/src/utils_crc.o
+CC build_out/lwip/src/core/ipv4/icmp.o
+AR build_out/newlibc/libnewlibc.a
+CC build_out/lwip/src/core/ipv4/igmp.o
+CC build_out/utils/src/utils_sha256.o
+CC build_out/utils/src/utils_fec.o
+CC build_out/lwip/src/core/ipv4/ip4.o
+CC build_out/hosal/sec_common/bl_sec_pka.o
+CC build_out/mbedtls_lts/mbedtls/library/aesni.o
+CC build_out/mbedtls_lts/mbedtls/library/arc4.o
+CC build_out/mbedtls_lts/mbedtls/library/aria.o
+CC build_out/hosal/sec_common/bl_sec_aes.o
+CC build_out/hosal/sec_common/bl_sec_gmac.o
+CC build_out/mbedtls_lts/mbedtls/library/asn1parse.o
+CC build_out/lwip/src/core/ipv4/ip4_addr.o
+CC build_out/lwip/src/core/ipv4/ip4_frag.o
+CC build_out/lwip/src/core/mem.o
+CC build_out/lwip/src/core/memp.o
+CC build_out/lwip/src/core/netif.o
+CC build_out/lwip/src/core/pbuf.o
+AR build_out/hosal/libhosal.a
+CC build_out/vfs/src/vfs.o
+CC build_out/mbedtls_lts/mbedtls/library/asn1write.o
+AR build_out/romfs/libromfs.a
+CC build_out/yloop/src/yloop.o
+CC build_out/lwip/src/core/raw.o
+CC build_out/lwip/src/core/stats.o
+CC build_out/utils/src/utils_log.o
+CC build_out/lwip/src/core/sys.o
+CC build_out/lwip/src/core/tcp.o
+CC build_out/lwip/src/core/tcp_in.o
+CC build_out/utils/src/utils_dns.o
+CC build_out/yloop/src/select.o
+CC build_out/lwip/src/core/tcp_out.o
+CC build_out/mbedtls_lts/mbedtls/library/base64.o
+CC build_out/utils/src/utils_list.o
+CC build_out/vfs/src/vfs_file.o
+CC build_out/yloop/src/aos_freertos.o
+CC build_out/yloop/src/device.o
+CC build_out/mbedtls_lts/mbedtls/library/blowfish.o
+CC build_out/utils/src/utils_ringblk.o
+CC build_out/vfs/src/vfs_inode.o
+CC build_out/mbedtls_lts/mbedtls/library/camellia.o
+CC build_out/mbedtls_lts/mbedtls/library/ccm.o
+CC build_out/yloop/src/local_event.o
+CC build_out/mbedtls_lts/mbedtls/library/certs.o
+CC build_out/mbedtls_lts/mbedtls/library/chacha20.o
+CC build_out/mbedtls_lts/mbedtls/library/chachapoly.o
+CC build_out/vfs/src/vfs_register.o
+CC build_out/utils/src/utils_rbtree.o
+CC build_out/mbedtls_lts/mbedtls/library/cipher.o
+AR build_out/yloop/libyloop.a
+CC build_out/utils/src/utils_hexdump.o
+CC build_out/utils/src/utils_time.o
+CC build_out/vfs/device/vfs_uart.o
+CC build_out/utils/src/utils_notifier.o
+CC build_out/utils/src/utils_getopt.o
+CC build_out/utils/src/utils_string.o
+CC build_out/lwip/src/core/timeouts.o
+CC build_out/utils/src/utils_hmac_sha1_fast.o
+CC build_out/lwip/src/core/udp.o
+CC build_out/utils/src/utils_psk_fast.o
+CC build_out/lwip/src/core/utils.o
+CC build_out/mbedtls_lts/mbedtls/library/cipher_wrap.o
+CC build_out/vfs/device/vfs_adc.o
+CC build_out/utils/src/utils_memp.o
+CC build_out/utils/src/utils_tlv_bl.o
+CC build_out/utils/src/utils_base64.o
+CC build_out/mbedtls_lts/mbedtls/library/cmac.o
+CC build_out/mbedtls_lts/mbedtls/library/constant_time.o
+CC build_out/lwip/src/netif/bridgeif.o
+CC build_out/lwip/src/netif/bridgeif_fdb.o
+CC build_out/lwip/src/netif/ethernet.o
+CC build_out/lwip/src/netif/lowpan6.o
+CC build_out/vfs/device/vfs_spi.o
+CC build_out/lwip/src/netif/lowpan6_ble.o
+CC build_out/mbedtls_lts/mbedtls/library/ctr_drbg.o
+CC build_out/mbedtls_lts/mbedtls/library/debug.o
+CC build_out/lwip/src/netif/lowpan6_common.o
+CC build_out/utils/src/utils_bitmap_window.o
+CC build_out/vfs/device/vfs_gpio.o
+CC build_out/lwip/src/netif/slipif.o
+CC build_out/vfs/device/vfs_pwm.o
+CC build_out/utils/src/test/test_utils_base64.o
+CC build_out/utils/src/test/test_utils_ringblk.o
+CC build_out/utils/src/test/test_utils_bitmap_window.o
+AR build_out/vfs/libvfs.a
+CC build_out/lwip/src/netif/zepif.o
+CC build_out/mbedtls_lts/mbedtls/library/des.o
+CC build_out/mbedtls_lts/mbedtls/library/dhm.o
+CC build_out/mbedtls_lts/mbedtls/library/ecdh.o
+AR build_out/lwip/liblwip.a
+CC build_out/mbedtls_lts/mbedtls/library/ecdsa.o
+CC build_out/mbedtls_lts/mbedtls/library/ecjpake.o
+CC build_out/mbedtls_lts/mbedtls/library/ecp.o
+CC build_out/mbedtls_lts/mbedtls/library/ecp_curves.o
+CC build_out/mbedtls_lts/mbedtls/library/entropy.o
+CC build_out/mbedtls_lts/mbedtls/library/entropy_poll.o
+CC build_out/mbedtls_lts/mbedtls/library/error.o
+AR build_out/utils/libutils.a
+CC build_out/mbedtls_lts/mbedtls/library/gcm.o
+CC build_out/mbedtls_lts/mbedtls/library/havege.o
+CC build_out/mbedtls_lts/mbedtls/library/hkdf.o
+CC build_out/mbedtls_lts/mbedtls/library/hmac_drbg.o
+CC build_out/mbedtls_lts/mbedtls/library/md2.o
+CC build_out/mbedtls_lts/mbedtls/library/md4.o
+CC build_out/mbedtls_lts/mbedtls/library/md5.o
+CC build_out/mbedtls_lts/mbedtls/library/md.o
+CC build_out/mbedtls_lts/mbedtls/library/memory_buffer_alloc.o
+CC build_out/mbedtls_lts/mbedtls/library/mps_reader.o
+CC build_out/mbedtls_lts/mbedtls/library/mps_trace.o
+CC build_out/mbedtls_lts/mbedtls/library/nist_kw.o
+CC build_out/mbedtls_lts/mbedtls/library/oid.o
+CC build_out/mbedtls_lts/mbedtls/library/padlock.o
+CC build_out/mbedtls_lts/mbedtls/library/pem.o
+CC build_out/mbedtls_lts/mbedtls/library/pk.o
+CC build_out/mbedtls_lts/mbedtls/library/pkcs11.o
+CC build_out/mbedtls_lts/mbedtls/library/pkcs12.o
+CC build_out/mbedtls_lts/mbedtls/library/pkcs5.o
+CC build_out/mbedtls_lts/mbedtls/library/pk_wrap.o
+CC build_out/mbedtls_lts/mbedtls/library/pkwrite.o
+CC build_out/mbedtls_lts/mbedtls/library/platform.o
+CC build_out/mbedtls_lts/mbedtls/library/platform_util.o
+CC build_out/mbedtls_lts/mbedtls/library/poly1305.o
+CC build_out/mbedtls_lts/mbedtls/library/ripemd160.o
+CC build_out/mbedtls_lts/mbedtls/library/rsa.o
+CC build_out/mbedtls_lts/mbedtls/library/rsa_internal.o
+CC build_out/mbedtls_lts/mbedtls/library/sha1.o
+CC build_out/mbedtls_lts/mbedtls/library/sha256.o
+CC build_out/mbedtls_lts/mbedtls/library/sha512.o
+CC build_out/mbedtls_lts/mbedtls/library/ssl_cache.o
+CC build_out/mbedtls_lts/mbedtls/library/ssl_ciphersuites.o
+CC build_out/mbedtls_lts/mbedtls/library/ssl_cli.o
+CC build_out/mbedtls_lts/mbedtls/library/ssl_cookie.o
+CC build_out/mbedtls_lts/mbedtls/library/ssl_msg.o
+CC build_out/mbedtls_lts/mbedtls/library/ssl_srv.o
+CC build_out/mbedtls_lts/mbedtls/library/ssl_ticket.o
+CC build_out/mbedtls_lts/mbedtls/library/ssl_tls13_keys.o
+CC build_out/mbedtls_lts/mbedtls/library/ssl_tls.o
+CC build_out/mbedtls_lts/mbedtls/library/threading.o
+CC build_out/mbedtls_lts/mbedtls/library/timing.o
+CC build_out/mbedtls_lts/mbedtls/library/version.o
+CC build_out/mbedtls_lts/mbedtls/library/version_features.o
+CC build_out/mbedtls_lts/mbedtls/library/x509.o
+CC build_out/mbedtls_lts/mbedtls/library/x509_create.o
+CC build_out/mbedtls_lts/mbedtls/library/x509_crl.o
+CC build_out/mbedtls_lts/mbedtls/library/x509_crt.o
+CC build_out/mbedtls_lts/mbedtls/library/x509_csr.o
+CC build_out/mbedtls_lts/mbedtls/library/x509write_crt.o
+CC build_out/mbedtls_lts/mbedtls/library/x509write_csr.o
+CC build_out/mbedtls_lts/port/pkparse.o
+CC build_out/mbedtls_lts/port/mbedtls_port_mem.o
+CC build_out/mbedtls_lts/port/net_sockets.o
+CC build_out/mbedtls_lts/port/hw_entropy_poll.o
+CC build_out/mbedtls_lts/port/bignum_ext.o
+CC build_out/mbedtls_lts/mbedtls/library/bignum.o
+CC build_out/mbedtls_lts/port/test_case.o
+AR build_out/mbedtls_lts/libmbedtls_lts.a
+LD build_out/helloworld.elf
+Generating BIN File to /home/fae/codex-builds/Ai-Thinker-WB2-2420da7/applications/get-started/helloworld/build_out/helloworld.bin
+Building Finish. To flash build output. run 'make flash' or:
+c  ...
+cd /home/fae/codex-builds/Ai-Thinker-WB2-2420da7/tools/flash_tool && env SDK_APP_BIN=/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/applications/get-started/helloworld/build_out/helloworld.bin SDK_BOARD=evb SDK_NAME=helloworld SDK_MEDIA_BIN= SDK_ROMFS_DIR= SDK_DTS= SDK_XTAL= BL_FLASH_TOOL_INPUT_PATH_cfg2_bin_input=/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/applications/get-started/helloworld/build_out/helloworld.bin ./bflb_iot_tool-ubuntu --chipname=BL602 --baudrate=921600 --port=/dev/ttyUSB0 --pt=/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/applications/get-started/helloworld/img_conf/partition_cfg_2M.toml --dts=/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/applications/get-started/helloworld/img_conf/bl_factory_params_IoTKitA_40M.dts --firmware=/home/fae/codex-builds/Ai-Thinker-WB2-2420da7/applications/get-started/helloworld/build_out/helloworld.bin
+ELAPSED_SECONDS=5.18


### PR DESCRIPTION
## 中文

- 按统一规范把 README、代码入口、架构说明、构建验证拆分为英文主文件与 .zh.md 中文文件，并添加语言切换徽章
- 记录 BL602 平台到应用 main 的真实调用链和组件构建关系
- 在 WSL2 原生文件系统对 applications/get-started/helloworld 完成两次干净构建
- 两次均为 11 warnings、0 errors，保存完整日志、ELF 符号、产物大小和 SHA-256
- 不修改 SDK 源码、工具链 Gitlink、Release、Tag、分支保护或硬件配置

## English

- Split the README, code-entry, architecture, and build-validation documents into English main files and .zh.md Chinese counterparts with language badges
- Record the source-backed BL602 platform-to-application entry path and component build relationships
- Complete two clean builds of applications/get-started/helloworld in the WSL2 native file system
- Both builds report 11 warnings and 0 errors; preserve logs, ELF symbols, output sizes, and SHA-256 hashes
- Leave SDK source, toolchain Gitlinks, releases, tags, branch protection, and hardware configuration unchanged

## Validation

- Build 1: 5.37 s, 11 warnings, 0 errors
- Build 2: 5.18 s, 11 warnings, 0 errors
- Recalculated health score: 86/A (governance 27/40, technical 59/60)
- Not covered: flashing, hardware boot, RF/Wi-Fi/BLE/peripheral testing, or the full application matrix